### PR TITLE
feat: extra tile source selection for offline regions

### DIFF
--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -41,6 +41,33 @@ await manager.addRegion({
 });
 ```
 
+You can also include additional tile sources that are not part of the style:
+
+```typescript
+await manager.addRegion({
+  id: 'my-region',
+  name: 'My Region',
+  bounds: [[-74.05, 40.71], [-74.00, 40.76]],
+  minZoom: 10,
+  maxZoom: 16,
+  styleUrl: 'https://example.com/style.json',
+  extraSources: [
+    {
+      id: 'buildings',
+      type: 'vector',
+      tiles: ['https://tiles.example.com/buildings/{z}/{x}/{y}.pbf'],
+      minzoom: 13,
+      maxzoom: 16,
+    },
+    {
+      id: 'custom-overlay',
+      type: 'vector',
+      tiles: ['https://tiles.example.com/overlay/{z}/{x}/{y}.mvt'],
+    },
+  ],
+});
+```
+
 #### `getStoredRegion(id: string): Promise<StoredRegion | null>`
 
 Retrieve a stored region by its ID.
@@ -540,6 +567,29 @@ interface OfflineRegionOptions {
   deleteOnExpiry?: boolean;
   /** Tile extension (pbf, mvt, png, jpg, etc.) */
   tileExtension?: string;
+  /** Additional tile sources to download alongside the style's own sources */
+  extraSources?: ExtraSource[];
+}
+```
+
+### ExtraSource
+
+Defines an additional tile source to download alongside the style's own sources. This allows saving extra vector (MVT/PBF) or raster layers for a region.
+
+```typescript
+interface ExtraSource {
+  /** Unique identifier for this source (used as sourceId in tile keys and style sources) */
+  id: string;
+  /** Source type. Defaults to 'vector'. */
+  type?: 'vector' | 'raster' | 'raster-dem';
+  /** Tile URL template(s) with {z}, {x}, {y} placeholders */
+  tiles: string[];
+  /** Minimum zoom level for this source */
+  minzoom?: number;
+  /** Maximum zoom level for this source */
+  maxzoom?: number;
+  /** Attribution string for this source */
+  attribution?: string;
 }
 ```
 

--- a/docs/docs/examples.md
+++ b/docs/docs/examples.md
@@ -10,6 +10,7 @@ Practical examples for common use cases with `map-gl-offline`.
 
 - [Basic Usage](#basic-usage)
 - [Mapbox GL JS](#mapbox-gl-js)
+- [Extra Tile Sources](#extra-tile-sources)
 - [Region Management](#region-management)
 - [Import/Export](#importexport)
 - [Offline Detection](#offline-detection)
@@ -176,6 +177,87 @@ function setWeather(mode: 'none' | 'rain' | 'snow') {
     map.setSnow({ intensity: 0.6, color: '#ffffff' });
   }
 }
+```
+
+---
+
+## Extra Tile Sources
+
+Save additional vector or raster tile layers alongside the style's own sources. This is useful when you have custom overlay layers that are not part of the base map style.
+
+### Download Region with Extra Vector Layers
+
+```typescript
+await manager.addRegion({
+  id: 'downtown-with-layers',
+  name: 'Downtown + Custom Layers',
+  bounds: [[-74.05, 40.71], [-74.00, 40.76]],
+  minZoom: 10,
+  maxZoom: 16,
+  styleUrl: 'https://example.com/style.json',
+  extraSources: [
+    {
+      id: 'buildings-3d',
+      type: 'vector',
+      tiles: ['https://tiles.example.com/buildings/{z}/{x}/{y}.pbf'],
+      minzoom: 13,
+      maxzoom: 16,
+    },
+    {
+      id: 'transit-lines',
+      type: 'vector',
+      tiles: ['https://tiles.example.com/transit/{z}/{x}/{y}.mvt'],
+      minzoom: 8,
+      maxzoom: 16,
+      attribution: '&copy; Transit Authority',
+    },
+  ],
+});
+```
+
+### Extract Sources from Live Map
+
+When using the UI control, the region form automatically discovers tile sources from the live map and presents them as checkboxes for the user to select. For programmatic use:
+
+```typescript
+// Get all sources from the current map style
+const style = map.getStyle();
+const extraSources = Object.entries(style.sources)
+  .filter(([, source]) => {
+    const s = source as { type: string; tiles?: string[] };
+    return ['vector', 'raster', 'raster-dem'].includes(s.type) && s.tiles?.length;
+  })
+  .map(([id, source]) => {
+    const s = source as { type: string; tiles: string[]; minzoom?: number; maxzoom?: number };
+    return { id, type: s.type, tiles: s.tiles, minzoom: s.minzoom, maxzoom: s.maxzoom };
+  });
+
+// Use the extracted sources in a region download
+await manager.addRegion({
+  id: 'full-offline',
+  name: 'Full Offline Region',
+  bounds: [[-74.05, 40.71], [-74.00, 40.76]],
+  minZoom: 10,
+  maxZoom: 16,
+  styleUrl: 'https://example.com/style.json',
+  extraSources,
+});
+```
+
+### UI Control with Source Selection
+
+When using the `OfflineManagerControl`, the region download form automatically shows all tile sources from the map as selectable checkboxes. Users can pick which additional layers to include in the offline region.
+
+```typescript
+const control = new OfflineManagerControl(manager, {
+  styleUrl: 'https://example.com/style.json',
+  mapLib: maplibregl,
+});
+map.addControl(control, 'top-right');
+
+// When the user draws a region and opens the download form,
+// all vector/raster sources on the map are shown as checkboxes.
+// Selected sources are downloaded alongside the base style tiles.
 ```
 
 ---

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -15,6 +15,7 @@ A comprehensive **TypeScript** library for **MapLibre GL JS** and **Mapbox GL JS
 
 - **Complete Offline Maps** - Download and store entire map regions with polygon-based selection
 - **Smart Tile Management** - Efficient vector/raster tile downloading, caching, and retrieval
+- **Extra Layer Support** - Save additional vector (MVT/PBF) and raster tile sources alongside the style
 - **Font & Glyph Support** - Comprehensive font and glyph management with Unicode range support
 - **Sprite Management** - Handle map sprites and icons offline with multi-resolution support
 - **Real-time Analytics** - Detailed storage analytics and optimization recommendations

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "map-gl-offline",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "map-gl-offline",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "license": "MIT",
       "dependencies": {
         "@mapbox/tilebelt": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "map-gl-offline",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "A TypeScript-compatible npm package for MapLibre GL JS that enables comprehensive offline storage and usage of vector/raster tiles, sprites, styles, fonts (glyphs), and entire map regions with advanced analytics, import/export capabilities, and intelligent cleanup.",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/src/services/regionService.ts
+++ b/src/services/regionService.ts
@@ -223,6 +223,22 @@ export class RegionService {
       styleEntry.regions = [];
     }
 
+    // Inject extra sources into the style so they get patched for offline use
+    if (region.extraSources && region.extraSources.length > 0) {
+      for (const extra of region.extraSources) {
+        if (!styleEntry.style.sources[extra.id]) {
+          styleEntry.style.sources[extra.id] = {
+            type: extra.type || 'vector',
+            tiles: extra.tiles,
+            ...(extra.minzoom !== undefined ? { minzoom: extra.minzoom } : {}),
+            ...(extra.maxzoom !== undefined ? { maxzoom: extra.maxzoom } : {}),
+            ...(extra.attribution ? { attribution: extra.attribution } : {}),
+          };
+          regionLogger.debug(`Injected extra source into style: ${extra.id}`);
+        }
+      }
+    }
+
     // Patch style for offline use with the region's maxZoom and tileExtension
     // Pass styleId for sprites since they're stored with the style ID, not region ID
     patchStyleForOffline(

--- a/src/services/tileService.ts
+++ b/src/services/tileService.ts
@@ -73,6 +73,22 @@ export class TileService {
       throw new Error('Style does not contain any sources to download tiles from');
     }
 
+    // Inject extra sources from the region into the style for downloading
+    if (region.extraSources && region.extraSources.length > 0) {
+      for (const extra of region.extraSources) {
+        if (!style.sources[extra.id]) {
+          style.sources[extra.id] = {
+            type: extra.type || 'vector',
+            tiles: extra.tiles,
+            ...(extra.minzoom !== undefined ? { minzoom: extra.minzoom } : {}),
+            ...(extra.maxzoom !== undefined ? { maxzoom: extra.maxzoom } : {}),
+            ...(extra.attribution ? { attribution: extra.attribution } : {}),
+          };
+          tileLogger.debug(`Injected extra source: ${extra.id}`, extra.tiles);
+        }
+      }
+    }
+
     // Generate tile coordinates once for the region
     const tileCoords = this.generateTileCoordinates(region);
 

--- a/src/types/region.ts
+++ b/src/types/region.ts
@@ -18,6 +18,30 @@ export interface StoredRegion extends OfflineRegionOptions {
 }
 
 /**
+ * An additional tile source to download alongside the style's own sources.
+ * Allows saving extra vector (MVT/PBF) or raster layers for a region.
+ */
+export interface ExtraSource {
+  /** Unique identifier for this source (used as sourceId in tile keys and style sources) */
+  id: string;
+  /**
+   * Source type. Defaults to 'vector'.
+   */
+  type?: 'vector' | 'raster' | 'raster-dem';
+  /**
+   * Tile URL template(s) with {z}, {x}, {y} placeholders.
+   * Example: 'https://example.com/tiles/{z}/{x}/{y}.pbf'
+   */
+  tiles: string[];
+  /** Minimum zoom level for this source */
+  minzoom?: number;
+  /** Maximum zoom level for this source */
+  maxzoom?: number;
+  /** Attribution string for this source */
+  attribution?: string;
+}
+
+/**
  * Configuration options for an offline region
  */
 export interface OfflineRegionOptions {
@@ -55,4 +79,9 @@ export interface OfflineRegionOptions {
   deleteOnExpiry?: boolean;
   /** The actual tile extension used (mvt, pbf, png, jpg, etc.) */
   tileExtension?: string;
+  /**
+   * Additional tile sources to download alongside the style's own sources.
+   * These are injected into the style for offline rendering.
+   */
+  extraSources?: ExtraSource[];
 }

--- a/src/ui/controls/regionControl.ts
+++ b/src/ui/controls/regionControl.ts
@@ -5,7 +5,12 @@
 
 import type { Map as MaplibreMap } from 'maplibre-gl';
 import { PolygonControl, PolygonControlOptions } from './polygonControl';
-import { RegionFormModal, RegionFormData, RegionFormOptions } from '@/ui/modals/regionFormModal';
+import {
+  RegionFormModal,
+  RegionFormData,
+  RegionFormOptions,
+  MapTileSource,
+} from '@/ui/modals/regionFormModal';
 import { DownloadManager } from '@/ui/managers/downloadManager';
 import { ModalManager } from '@/ui/modals/modalManager';
 import { icons } from '@/utils/icons';
@@ -129,9 +134,52 @@ export class RegionControl {
   }
 
   /**
+   * Extract tile sources from the live map instance.
+   * Returns vector, raster, and raster-dem sources that have tile URLs.
+   */
+  private extractMapSources(): MapTileSource[] {
+    try {
+      const style = (this.map as { getStyle?: () => Record<string, unknown> })?.getStyle?.();
+      if (!style || !style.sources || typeof style.sources !== 'object') return [];
+
+      const sources: MapTileSource[] = [];
+      for (const [id, raw] of Object.entries(
+        style.sources as Record<string, Record<string, unknown>>
+      )) {
+        const type = raw.type as string | undefined;
+        if (type !== 'vector' && type !== 'raster' && type !== 'raster-dem') continue;
+
+        const tiles = raw.tiles as string[] | undefined;
+        // Only include sources that have resolvable tile URLs (not idb://)
+        if (!tiles || !Array.isArray(tiles) || tiles.length === 0) continue;
+        const hasHttpTiles = tiles.some(
+          (t: string) => t.startsWith('http://') || t.startsWith('https://')
+        );
+        if (!hasHttpTiles) continue;
+
+        sources.push({
+          id,
+          type: type as MapTileSource['type'],
+          tiles: tiles.filter((t: string) => t.startsWith('http://') || t.startsWith('https://')),
+          minzoom: typeof raw.minzoom === 'number' ? raw.minzoom : undefined,
+          maxzoom: typeof raw.maxzoom === 'number' ? raw.maxzoom : undefined,
+          attribution: typeof raw.attribution === 'string' ? raw.attribution : undefined,
+        });
+      }
+      return sources;
+    } catch (error) {
+      regionLogger.warn('Failed to extract map sources:', error);
+      return [];
+    }
+  }
+
+  /**
    * Show region form modal
    */
   private showRegionForm(bounds: [number, number, number, number], area: number): void {
+    const mapSources = this.extractMapSources();
+    regionLogger.debug(`Discovered ${mapSources.length} tile sources from map`);
+
     const formOptions: RegionFormOptions = {
       bounds,
       area,
@@ -140,6 +188,7 @@ export class RegionControl {
       styleUrl: this.options.styleUrl,
       accessToken: this.options.accessToken,
       onThemeToggle: () => this.options.onRegionSaved?.(),
+      mapSources,
     };
 
     this.regionFormModal = new RegionFormModal(formOptions);

--- a/src/ui/controls/regionControl.ts
+++ b/src/ui/controls/regionControl.ts
@@ -134,18 +134,47 @@ export class RegionControl {
   }
 
   /**
-   * Extract tile sources from the live map instance.
-   * Returns vector, raster, and raster-dem sources that have tile URLs.
+   * Get the source IDs that belong to the current style URL.
+   * These are the sources the style already includes and will be downloaded automatically.
    */
-  private extractMapSources(): MapTileSource[] {
+  private async getStyleSourceIds(): Promise<Set<string>> {
+    try {
+      const styleUrl = this.options.styleUrl;
+      if (!styleUrl) return new Set();
+
+      const response = await fetch(styleUrl);
+      if (!response.ok) return new Set();
+
+      const styleJson = (await response.json()) as { sources?: Record<string, unknown> };
+      if (styleJson.sources && typeof styleJson.sources === 'object') {
+        return new Set(Object.keys(styleJson.sources));
+      }
+    } catch (error) {
+      regionLogger.warn('Failed to fetch style for source filtering:', error);
+    }
+    return new Set();
+  }
+
+  /**
+   * Extract tile sources from the live map instance that are NOT part of the current style.
+   * Returns vector, raster, and raster-dem sources that have tile URLs,
+   * excluding sources that already belong to the style (those are downloaded automatically).
+   */
+  private async extractExtraMapSources(): Promise<MapTileSource[]> {
     try {
       const style = (this.map as { getStyle?: () => Record<string, unknown> })?.getStyle?.();
       if (!style || !style.sources || typeof style.sources !== 'object') return [];
+
+      // Fetch the original style's source IDs so we can exclude them
+      const styleSourceIds = await this.getStyleSourceIds();
 
       const sources: MapTileSource[] = [];
       for (const [id, raw] of Object.entries(
         style.sources as Record<string, Record<string, unknown>>
       )) {
+        // Skip sources that belong to the style itself
+        if (styleSourceIds.has(id)) continue;
+
         const type = raw.type as string | undefined;
         if (type !== 'vector' && type !== 'raster' && type !== 'raster-dem') continue;
 
@@ -176,9 +205,12 @@ export class RegionControl {
   /**
    * Show region form modal
    */
-  private showRegionForm(bounds: [number, number, number, number], area: number): void {
-    const mapSources = this.extractMapSources();
-    regionLogger.debug(`Discovered ${mapSources.length} tile sources from map`);
+  private async showRegionForm(
+    bounds: [number, number, number, number],
+    area: number
+  ): Promise<void> {
+    const mapSources = await this.extractExtraMapSources();
+    regionLogger.debug(`Discovered ${mapSources.length} extra tile sources from map`);
 
     const formOptions: RegionFormOptions = {
       bounds,

--- a/src/ui/managers/downloadManager.ts
+++ b/src/ui/managers/downloadManager.ts
@@ -194,6 +194,7 @@ export class DownloadManager {
       minZoom: formData.minZoom,
       maxZoom: formData.maxZoom,
       styleUrl: formData.styleUrl,
+      extraSources: formData.extraSources,
     };
 
     const regionId = regionConfig.id;

--- a/src/ui/modals/regionFormModal.ts
+++ b/src/ui/modals/regionFormModal.ts
@@ -9,6 +9,7 @@ import { Modal, ModalConfig } from '@/ui/components/shared/Modal';
 import { Button } from '@/ui/components/shared/Button';
 import { icons } from '@/utils/icons';
 import { logger } from '@/utils/logger';
+import { escapeHtml } from '@/utils/formatting';
 import { t, i18n } from '@/ui/translations';
 
 const formLogger = logger.scope('RegionFormModal');
@@ -23,6 +24,26 @@ export interface RegionFormData {
   // Enhanced Mapbox GL support
   provider?: 'mapbox' | 'maplibre' | 'auto';
   accessToken?: string;
+  /** Additional tile sources to download alongside the style's own sources */
+  extraSources?: import('@/types/region').ExtraSource[];
+}
+
+/**
+ * A tile source discovered on the live map, presented to the user for selection.
+ */
+export interface MapTileSource {
+  /** Source ID as it appears in the style */
+  id: string;
+  /** Source type */
+  type: 'vector' | 'raster' | 'raster-dem';
+  /** Tile URL templates */
+  tiles: string[];
+  /** Min zoom level */
+  minzoom?: number;
+  /** Max zoom level */
+  maxzoom?: number;
+  /** Attribution */
+  attribution?: string;
 }
 
 export interface RegionFormOptions {
@@ -33,6 +54,8 @@ export interface RegionFormOptions {
   onThemeToggle?: () => void;
   styleUrl: string;
   accessToken?: string;
+  /** Tile sources discovered from the live map for user selection */
+  mapSources?: MapTileSource[];
 }
 
 export class RegionFormModal {
@@ -46,6 +69,9 @@ export class RegionFormModal {
   private providerSelect?: HTMLSelectElement;
   private accessTokenInput?: HTMLInputElement;
   private accessTokenGroup?: HTMLDivElement;
+  // Extra sources picker
+  private sourceCheckboxes: Map<string, { checkbox: HTMLInputElement; source: MapTileSource }> =
+    new Map();
 
   constructor(options: RegionFormOptions) {
     this.options = options;
@@ -240,10 +266,141 @@ export class RegionFormModal {
 
     form.appendChild(this.accessTokenGroup);
 
+    // Extra sources picker
+    if (this.options.mapSources && this.options.mapSources.length > 0) {
+      const sourcesSection = this.createSourcesPicker(this.options.mapSources);
+      form.appendChild(sourcesSection);
+    }
+
     // Initialize provider detection
     this.detectProviderFromUrl();
 
     return form;
+  }
+
+  /**
+   * Create the extra sources picker section
+   */
+  private createSourcesPicker(sources: MapTileSource[]): HTMLElement {
+    const group = document.createElement('div');
+    group.className = 'flex flex-col gap-3';
+
+    // Header with label and select all/deselect all
+    const header = document.createElement('div');
+    header.className = 'flex items-center justify-between';
+    header.innerHTML = `
+      <label class="block text-sm font-semibold text-gray-700 dark:text-gray-300">
+        ${t('regionForm.extraSources')}
+      </label>
+    `;
+
+    const toggleBtn = document.createElement('button');
+    toggleBtn.type = 'button';
+    toggleBtn.className =
+      'text-xs text-primary-600 dark:text-primary-400 hover:underline cursor-pointer font-medium';
+    toggleBtn.textContent = t('regionForm.selectAll');
+    let allSelected = false;
+    toggleBtn.addEventListener('click', () => {
+      allSelected = !allSelected;
+      for (const { checkbox } of this.sourceCheckboxes.values()) {
+        checkbox.checked = allSelected;
+      }
+      toggleBtn.textContent = allSelected ? t('regionForm.deselectAll') : t('regionForm.selectAll');
+    });
+    header.appendChild(toggleBtn);
+    group.appendChild(header);
+
+    // Info text
+    const info = document.createElement('div');
+    info.className = 'text-xs text-gray-500 dark:text-gray-400 flex items-center gap-1';
+    info.innerHTML = `${icons.infoCircle({ size: 12 })} ${t('regionForm.extraSourcesInfo')}`;
+    group.appendChild(info);
+
+    // Source list
+    const list = document.createElement('div');
+    list.className =
+      'flex flex-col gap-2 max-h-48 overflow-y-auto p-3 rounded-xl glass-input border border-gray-100/50 dark:border-gray-700/50 bg-gray-50/50 dark:bg-gray-800/50';
+
+    for (const source of sources) {
+      const row = document.createElement('label');
+      row.className =
+        'flex items-center gap-3 p-2 rounded-lg hover:bg-white/60 dark:hover:bg-gray-700/40 cursor-pointer transition-colors';
+
+      const checkbox = document.createElement('input');
+      checkbox.type = 'checkbox';
+      checkbox.className =
+        'w-4 h-4 rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500/50 cursor-pointer flex-shrink-0';
+      checkbox.value = source.id;
+      row.appendChild(checkbox);
+
+      this.sourceCheckboxes.set(source.id, { checkbox, source });
+
+      const details = document.createElement('div');
+      details.className = 'flex flex-col min-w-0';
+
+      const nameRow = document.createElement('div');
+      nameRow.className = 'flex items-center gap-2';
+
+      const name = document.createElement('span');
+      name.className = 'text-sm font-medium text-gray-800 dark:text-gray-200 truncate';
+      name.textContent = source.id;
+      nameRow.appendChild(name);
+
+      const typeKey = `regionForm.sourceType.${source.type}` as Parameters<typeof t>[0];
+      const badge = document.createElement('span');
+      badge.className =
+        source.type === 'vector'
+          ? 'text-[10px] px-1.5 py-0.5 rounded-full bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300 font-medium flex-shrink-0'
+          : source.type === 'raster'
+            ? 'text-[10px] px-1.5 py-0.5 rounded-full bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300 font-medium flex-shrink-0'
+            : 'text-[10px] px-1.5 py-0.5 rounded-full bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300 font-medium flex-shrink-0';
+      badge.textContent = t(typeKey);
+      nameRow.appendChild(badge);
+
+      details.appendChild(nameRow);
+
+      // Zoom range info
+      const zoomMin = source.minzoom ?? 0;
+      const zoomMax = source.maxzoom ?? 22;
+      const meta = document.createElement('span');
+      meta.className = 'text-[11px] text-gray-500 dark:text-gray-400 truncate';
+      meta.textContent = `z${zoomMin}-${zoomMax}`;
+      if (source.tiles.length > 0) {
+        try {
+          const hostname = new URL(source.tiles[0]).hostname;
+          meta.textContent += ` · ${escapeHtml(hostname)}`;
+        } catch {
+          // ignore invalid URLs
+        }
+      }
+      details.appendChild(meta);
+
+      row.appendChild(details);
+      list.appendChild(row);
+    }
+
+    group.appendChild(list);
+    return group;
+  }
+
+  /**
+   * Get the selected extra sources from the picker
+   */
+  private getSelectedExtraSources(): import('@/types/region').ExtraSource[] {
+    const selected: import('@/types/region').ExtraSource[] = [];
+    for (const { checkbox, source } of this.sourceCheckboxes.values()) {
+      if (checkbox.checked) {
+        selected.push({
+          id: source.id,
+          type: source.type,
+          tiles: source.tiles,
+          minzoom: source.minzoom,
+          maxzoom: source.maxzoom,
+          attribution: source.attribution,
+        });
+      }
+    }
+    return selected;
   }
 
   /**
@@ -340,6 +497,8 @@ export class RegionFormModal {
    */
   private async handleSave(): Promise<void> {
     try {
+      const selectedSources = this.getSelectedExtraSources();
+
       const formData: RegionFormData = {
         name: this.nameInput?.value || `Region ${Date.now()}`,
         minZoom: parseInt(this.minZoomInput?.value || '1'),
@@ -349,6 +508,7 @@ export class RegionFormModal {
         // Enhanced Mapbox GL support
         provider: this.providerSelect?.value as 'mapbox' | 'maplibre' | 'auto',
         accessToken: this.accessTokenInput?.value || undefined,
+        extraSources: selectedSources.length > 0 ? selectedSources : undefined,
       };
 
       this.modal?.hide();

--- a/src/ui/translations/ar.ts
+++ b/src/ui/translations/ar.ts
@@ -62,6 +62,14 @@ export const ar = {
   'regionForm.downloadRegion': 'تحميل المنطقة',
   'regionForm.area': 'المساحة',
   'regionForm.bounds': 'الحدود',
+  'regionForm.extraSources': 'مصادر بلاطات إضافية',
+  'regionForm.extraSourcesInfo': 'اختر طبقات إضافية من الخريطة لتضمينها في هذه المنطقة',
+  'regionForm.noExtraSources': 'لم يتم العثور على مصادر بلاطات إضافية على الخريطة',
+  'regionForm.sourceType.vector': 'متجه',
+  'regionForm.sourceType.raster': 'نقطي',
+  'regionForm.sourceType.raster-dem': 'تضاريس',
+  'regionForm.selectAll': 'تحديد الكل',
+  'regionForm.deselectAll': 'إلغاء تحديد الكل',
 
   // Region List - قائمة المناطق
   'regionList.empty': 'لم يتم العثور على أنماط أو مناطق غير متصلة. انقر على "إضافة منطقة" للبدء.',

--- a/src/ui/translations/en.ts
+++ b/src/ui/translations/en.ts
@@ -61,6 +61,15 @@ export const en = {
   'regionForm.downloadRegion': 'Download Region',
   'regionForm.area': 'Area',
   'regionForm.bounds': 'Bounds',
+  'regionForm.extraSources': 'Additional Tile Sources',
+  'regionForm.extraSourcesInfo':
+    'Select extra layers from the map to include in this offline region',
+  'regionForm.noExtraSources': 'No additional tile sources found on the map',
+  'regionForm.sourceType.vector': 'Vector',
+  'regionForm.sourceType.raster': 'Raster',
+  'regionForm.sourceType.raster-dem': 'Terrain',
+  'regionForm.selectAll': 'Select All',
+  'regionForm.deselectAll': 'Deselect All',
 
   // Region List
   'regionList.empty': 'No offline styles or regions found. Click "Add Region" to get started.',

--- a/tests/services/regionService.test.ts
+++ b/tests/services/regionService.test.ts
@@ -174,6 +174,123 @@ describe('RegionService', () => {
       expect(style?.regions.length).toBe(1);
       expect(style?.regions[0].name).toBe('New Region');
     });
+
+    it('should inject extraSources into the style when adding a region', async () => {
+      const db = await dbPromise;
+
+      // Add a style with an existing vector source
+      await db.put('styles', {
+        key: 'test-style-extra',
+        style: {
+          version: 8,
+          sources: {
+            'base-tiles': {
+              type: 'vector',
+              tiles: ['https://example.com/base/{z}/{x}/{y}.pbf'],
+            },
+          },
+          layers: [],
+        },
+        provider: 'auto' as StyleProvider,
+        regions: [],
+        fonts: [],
+        glyphs: [],
+        sprites: [],
+        originalUrl: 'https://example.com/style-extra.json',
+      });
+
+      const region = {
+        id: 'region-with-extras',
+        styleId: 'test-style-extra',
+        name: 'Region With Extra Layers',
+        bounds: [[-122.5, 37.5], [-122.0, 38.0]] as [[number, number], [number, number]],
+        minZoom: 0,
+        maxZoom: 10,
+        styleUrl: 'https://example.com/style-extra.json',
+        extraSources: [
+          {
+            id: 'buildings',
+            type: 'vector' as const,
+            tiles: ['https://example.com/buildings/{z}/{x}/{y}.pbf'],
+            minzoom: 12,
+            maxzoom: 16,
+          },
+          {
+            id: 'poi-layer',
+            type: 'vector' as const,
+            tiles: ['https://example.com/poi/{z}/{x}/{y}.mvt'],
+            attribution: '(c) Test',
+          },
+        ],
+      };
+
+      await regionService.addRegion(region);
+
+      // Verify extra sources were injected into the style
+      const style = await db.get('styles', 'test-style-extra');
+      expect(style?.style.sources['buildings']).toBeDefined();
+      expect(style?.style.sources['poi-layer']).toBeDefined();
+
+      // Verify the extra sources have idb:// tiles (patched for offline)
+      const buildingsSource = style?.style.sources['buildings'] as { tiles?: string[] };
+      expect(buildingsSource.tiles?.[0]).toMatch(/^idb:\/\//);
+
+      const poiSource = style?.style.sources['poi-layer'] as { tiles?: string[] };
+      expect(poiSource.tiles?.[0]).toMatch(/^idb:\/\//);
+
+      // Verify original base source was also patched
+      const baseSource = style?.style.sources['base-tiles'] as { tiles?: string[] };
+      expect(baseSource.tiles?.[0]).toMatch(/^idb:\/\//);
+    });
+
+    it('should not overwrite existing sources with extraSources of the same id', async () => {
+      const db = await dbPromise;
+
+      await db.put('styles', {
+        key: 'test-style-no-overwrite',
+        style: {
+          version: 8,
+          sources: {
+            'shared-source': {
+              type: 'vector',
+              tiles: ['https://original.com/{z}/{x}/{y}.pbf'],
+            },
+          },
+          layers: [],
+        },
+        provider: 'auto' as StyleProvider,
+        regions: [],
+        fonts: [],
+        glyphs: [],
+        sprites: [],
+        originalUrl: 'https://example.com/style-no-overwrite.json',
+      });
+
+      const region = {
+        id: 'region-no-overwrite',
+        styleId: 'test-style-no-overwrite',
+        name: 'Test',
+        bounds: [[-122.5, 37.5], [-122.0, 38.0]] as [[number, number], [number, number]],
+        minZoom: 0,
+        maxZoom: 10,
+        styleUrl: 'https://example.com/style-no-overwrite.json',
+        extraSources: [
+          {
+            id: 'shared-source',
+            type: 'vector' as const,
+            tiles: ['https://different.com/{z}/{x}/{y}.pbf'],
+          },
+        ],
+      };
+
+      await regionService.addRegion(region);
+
+      // The original source should be preserved, not overwritten
+      const style = await db.get('styles', 'test-style-no-overwrite');
+      const source = style?.style.sources['shared-source'] as { tiles?: string[] };
+      // It should be patched to idb:// but from the original URL, not the extra source URL
+      expect(source.tiles?.[0]).toMatch(/^idb:\/\//);
+    });
   });
 
   describe('deleteRegion', () => {

--- a/tests/ui/controls/regionControl.test.ts
+++ b/tests/ui/controls/regionControl.test.ts
@@ -26,7 +26,7 @@ jest.mock('../../../src/ui/modals/regionFormModal', () => ({
 }));
 
 // Mock the map object
-const createMockMap = () => ({
+const createMockMap = (styleOverrides?: Record<string, unknown>) => ({
   getContainer: jest.fn().mockReturnValue(document.createElement('div')),
   getBounds: jest.fn().mockReturnValue({
     toArray: () => [[-122.5, 37.7], [-122.3, 37.9]],
@@ -39,6 +39,31 @@ const createMockMap = () => ({
   removeSource: jest.fn(),
   removeLayer: jest.fn(),
   getLayer: jest.fn().mockReturnValue(null),
+  getStyle: jest.fn().mockReturnValue({
+    version: 8,
+    sources: {
+      'openmaptiles': {
+        type: 'vector',
+        tiles: ['https://tiles.example.com/{z}/{x}/{y}.pbf'],
+        minzoom: 0,
+        maxzoom: 14,
+      },
+      'satellite': {
+        type: 'raster',
+        tiles: ['https://tiles.example.com/sat/{z}/{x}/{y}.png'],
+      },
+      'geojson-data': {
+        type: 'geojson',
+        data: { type: 'FeatureCollection', features: [] },
+      },
+      'offline-source': {
+        type: 'vector',
+        tiles: ['idb://region_1/tile/src/{z}/{x}/{y}.pbf'],
+      },
+      ...styleOverrides,
+    },
+    layers: [],
+  }),
 });
 
 // Mock the ModalManager
@@ -300,6 +325,42 @@ describe('RegionControl', () => {
       control.startSelection();
 
       expect(mockPolygonControl.enter).toHaveBeenCalled();
+    });
+
+    it('should pass map tile sources to RegionFormModal on save', () => {
+      const { PolygonControl } = require('../../../src/ui/controls/polygonControl');
+      const { RegionFormModal } = require('../../../src/ui/modals/regionFormModal');
+
+      let savedOnSave: ((bounds: [number, number, number, number], area: number) => void) | undefined;
+      PolygonControl.mockImplementation((map: unknown, opts: { onSave: typeof savedOnSave }) => {
+        savedOnSave = opts.onSave;
+        return {
+          enter: jest.fn(),
+          exit: jest.fn(),
+          triggerSave: jest.fn(),
+        };
+      });
+
+      const options = createOptions();
+      const control = new RegionControl(options);
+      control.startSelection();
+
+      // Simulate polygon save callback
+      savedOnSave?.([-122.5, 37.7, -122.3, 37.9], 25);
+
+      // Verify RegionFormModal was called with mapSources
+      expect(RegionFormModal).toHaveBeenCalled();
+      const formOptions = RegionFormModal.mock.calls[RegionFormModal.mock.calls.length - 1][0];
+
+      // Should include HTTP tile sources (vector + raster) but NOT geojson or idb:// sources
+      expect(formOptions.mapSources).toBeDefined();
+      expect(formOptions.mapSources.length).toBe(2);
+
+      const sourceIds = formOptions.mapSources.map((s: { id: string }) => s.id);
+      expect(sourceIds).toContain('openmaptiles');
+      expect(sourceIds).toContain('satellite');
+      expect(sourceIds).not.toContain('geojson-data');
+      expect(sourceIds).not.toContain('offline-source');
     });
 
     it('should exit polygon control on cancel', () => {

--- a/tests/ui/controls/regionControl.test.ts
+++ b/tests/ui/controls/regionControl.test.ts
@@ -327,9 +327,23 @@ describe('RegionControl', () => {
       expect(mockPolygonControl.enter).toHaveBeenCalled();
     });
 
-    it('should pass map tile sources to RegionFormModal on save', () => {
+    it('should only pass extra sources (not style sources) to RegionFormModal on save', async () => {
       const { PolygonControl } = require('../../../src/ui/controls/polygonControl');
       const { RegionFormModal } = require('../../../src/ui/modals/regionFormModal');
+
+      // Mock fetch to return the style JSON with its own sources
+      // The style owns 'openmaptiles' - so it should be excluded from extra sources
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          version: 8,
+          sources: {
+            openmaptiles: { type: 'vector', url: 'https://tiles.example.com/v3.json' },
+          },
+          layers: [],
+        }),
+      });
+      global.fetch = mockFetch;
 
       let savedOnSave: ((bounds: [number, number, number, number], area: number) => void) | undefined;
       PolygonControl.mockImplementation((map: unknown, opts: { onSave: typeof savedOnSave }) => {
@@ -345,20 +359,24 @@ describe('RegionControl', () => {
       const control = new RegionControl(options);
       control.startSelection();
 
-      // Simulate polygon save callback
+      // Simulate polygon save callback (async now)
       savedOnSave?.([-122.5, 37.7, -122.3, 37.9], 25);
 
-      // Verify RegionFormModal was called with mapSources
+      // Wait for the async showRegionForm to complete
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      // Verify RegionFormModal was called with only extra sources
       expect(RegionFormModal).toHaveBeenCalled();
       const formOptions = RegionFormModal.mock.calls[RegionFormModal.mock.calls.length - 1][0];
 
-      // Should include HTTP tile sources (vector + raster) but NOT geojson or idb:// sources
+      // 'satellite' is extra (not in style), 'openmaptiles' is in style so excluded
       expect(formOptions.mapSources).toBeDefined();
-      expect(formOptions.mapSources.length).toBe(2);
+      expect(formOptions.mapSources.length).toBe(1);
+      expect(formOptions.mapSources[0].id).toBe('satellite');
 
+      // Should NOT include style's own source, geojson, or idb:// sources
       const sourceIds = formOptions.mapSources.map((s: { id: string }) => s.id);
-      expect(sourceIds).toContain('openmaptiles');
-      expect(sourceIds).toContain('satellite');
+      expect(sourceIds).not.toContain('openmaptiles');
       expect(sourceIds).not.toContain('geojson-data');
       expect(sourceIds).not.toContain('offline-source');
     });

--- a/tests/ui/modals/regionFormModal.test.ts
+++ b/tests/ui/modals/regionFormModal.test.ts
@@ -2,7 +2,7 @@
  * Tests for RegionFormModal Component
  */
 
-import { RegionFormModal, RegionFormOptions, RegionFormData } from '../../../src/ui/modals/regionFormModal';
+import { RegionFormModal, RegionFormOptions, RegionFormData, MapTileSource } from '../../../src/ui/modals/regionFormModal';
 
 describe('RegionFormModal', () => {
   let container: HTMLDivElement;
@@ -350,6 +350,165 @@ describe('RegionFormModal', () => {
 
       // Modal should be created with showThemeToggle: true
       expect(() => modal.show()).not.toThrow();
+    });
+  });
+
+  describe('extra sources picker', () => {
+    const testSources: MapTileSource[] = [
+      {
+        id: 'buildings',
+        type: 'vector',
+        tiles: ['https://example.com/buildings/{z}/{x}/{y}.pbf'],
+        minzoom: 12,
+        maxzoom: 16,
+      },
+      {
+        id: 'satellite',
+        type: 'raster',
+        tiles: ['https://example.com/satellite/{z}/{x}/{y}.png'],
+        minzoom: 0,
+        maxzoom: 18,
+      },
+      {
+        id: 'terrain',
+        type: 'raster-dem',
+        tiles: ['https://example.com/terrain/{z}/{x}/{y}.webp'],
+      },
+    ];
+
+    it('should not show sources section when no mapSources provided', () => {
+      const options = createOptions();
+      const modal = new RegionFormModal(options);
+      const element = modal.show();
+
+      expect(element.textContent).not.toContain('Additional Tile Sources');
+    });
+
+    it('should not show sources section when mapSources is empty', () => {
+      const options = createOptions({ mapSources: [] });
+      const modal = new RegionFormModal(options);
+      const element = modal.show();
+
+      expect(element.textContent).not.toContain('Additional Tile Sources');
+    });
+
+    it('should show sources section with checkboxes when mapSources provided', () => {
+      const options = createOptions({ mapSources: testSources });
+      const modal = new RegionFormModal(options);
+      const element = modal.show();
+
+      expect(element.textContent).toContain('Additional Tile Sources');
+      const checkboxes = element.querySelectorAll('input[type="checkbox"]');
+      expect(checkboxes.length).toBe(3);
+    });
+
+    it('should display source IDs', () => {
+      const options = createOptions({ mapSources: testSources });
+      const modal = new RegionFormModal(options);
+      const element = modal.show();
+
+      expect(element.textContent).toContain('buildings');
+      expect(element.textContent).toContain('satellite');
+      expect(element.textContent).toContain('terrain');
+    });
+
+    it('should display source type badges', () => {
+      const options = createOptions({ mapSources: testSources });
+      const modal = new RegionFormModal(options);
+      const element = modal.show();
+
+      expect(element.textContent).toContain('Vector');
+      expect(element.textContent).toContain('Raster');
+      expect(element.textContent).toContain('Terrain');
+    });
+
+    it('should display zoom range info', () => {
+      const options = createOptions({ mapSources: testSources });
+      const modal = new RegionFormModal(options);
+      const element = modal.show();
+
+      expect(element.textContent).toContain('z12-16');
+      expect(element.textContent).toContain('z0-18');
+    });
+
+    it('should have Select All button', () => {
+      const options = createOptions({ mapSources: testSources });
+      const modal = new RegionFormModal(options);
+      const element = modal.show();
+
+      expect(element.textContent).toContain('Select All');
+    });
+
+    it('should select all sources when Select All is clicked', () => {
+      const options = createOptions({ mapSources: testSources });
+      const modal = new RegionFormModal(options);
+      const element = modal.show();
+
+      // Find and click Select All button
+      const buttons = element.querySelectorAll('button[type="button"]');
+      const selectAllBtn = Array.from(buttons).find(
+        btn => btn.textContent?.trim() === 'Select All'
+      ) as HTMLButtonElement | undefined;
+      expect(selectAllBtn).toBeDefined();
+      selectAllBtn?.click();
+
+      const checkboxes = element.querySelectorAll('input[type="checkbox"]') as NodeListOf<HTMLInputElement>;
+      const allChecked = Array.from(checkboxes).every(cb => cb.checked);
+      expect(allChecked).toBe(true);
+    });
+
+    it('should deselect all sources when Deselect All is clicked', () => {
+      const options = createOptions({ mapSources: testSources });
+      const modal = new RegionFormModal(options);
+      const element = modal.show();
+
+      const buttons = element.querySelectorAll('button[type="button"]');
+      const toggleBtn = Array.from(buttons).find(
+        btn => btn.textContent?.trim() === 'Select All'
+      ) as HTMLButtonElement | undefined;
+
+      // Click twice: first selects all, second deselects all
+      toggleBtn?.click();
+      toggleBtn?.click();
+
+      const checkboxes = element.querySelectorAll('input[type="checkbox"]') as NodeListOf<HTMLInputElement>;
+      const noneChecked = Array.from(checkboxes).every(cb => !cb.checked);
+      expect(noneChecked).toBe(true);
+    });
+
+    it('should not include extraSources in formData when none selected', async () => {
+      const onSave = jest.fn().mockResolvedValue(undefined);
+      const options = createOptions({ onSave, mapSources: testSources });
+      const modal = new RegionFormModal(options);
+      modal.show();
+
+      await modal.save();
+
+      const formData = onSave.mock.calls[0][0] as RegionFormData;
+      expect(formData.extraSources).toBeUndefined();
+    });
+
+    it('should include selected extraSources in formData on save', async () => {
+      const onSave = jest.fn().mockResolvedValue(undefined);
+      const options = createOptions({ onSave, mapSources: testSources });
+      const modal = new RegionFormModal(options);
+      const element = modal.show();
+
+      // Check the first and third checkboxes
+      const checkboxes = element.querySelectorAll('input[type="checkbox"]') as NodeListOf<HTMLInputElement>;
+      checkboxes[0].checked = true; // buildings
+      checkboxes[2].checked = true; // terrain
+
+      await modal.save();
+
+      const formData = onSave.mock.calls[0][0] as RegionFormData;
+      expect(formData.extraSources).toBeDefined();
+      expect(formData.extraSources).toHaveLength(2);
+      expect(formData.extraSources![0].id).toBe('buildings');
+      expect(formData.extraSources![0].type).toBe('vector');
+      expect(formData.extraSources![0].tiles).toEqual(['https://example.com/buildings/{z}/{x}/{y}.pbf']);
+      expect(formData.extraSources![1].id).toBe('terrain');
+      expect(formData.extraSources![1].type).toBe('raster-dem');
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add ability to select extra tile sources when creating offline regions
- Exclude the style's own sources from the extra sources picker to avoid duplicates

## Test plan
- [ ] Create a region and verify the extra sources picker only shows non-style sources
- [ ] Confirm selected extra sources are downloaded and stored offline
- [ ] Run `npm test` and `npm run typecheck`