### PR TITLE
feat: programmatic downloadRegion API (closes #18)

### DIFF
--- a/AUDIT_FINDINGS.md
+++ b/AUDIT_FINDINGS.md
@@ -1,0 +1,175 @@
+# Audit Findings — map-gl-offline
+
+**Date:** 2026-04-20
+**Context:** Surfaced during the PR #19 audit (programmatic `downloadRegion` API + duplicate-code cleanup). These are **pre-existing** bugs found while reading the surrounding code — they are not introduced by PR #19 and deserve focused follow-up work.
+
+Priority is rated **P1** (correctness bug, can corrupt data or silently drop work) or **P2** (minor/cosmetic).
+
+---
+
+## P1 — `expiry` field has inconsistent semantics (duration on write, timestamp on read)
+
+**Location:** `src/services/regionService.ts:270-276` (the write), with consuming reads at `src/services/cleanupService.ts:228`, `src/managers/offlineMapManager/cleanupManagement.ts:29`, `src/ui/components/RegionList.ts:103`, `src/services/regionService.ts:616` (loadAllStoredRegions).
+
+**Type definition** (`src/types/region.ts:76`):
+```ts
+/** Expiry timestamp (ms since epoch) */
+expiry?: number;
+```
+
+**Write path** in `addRegion`:
+```ts
+const expiryTime = region.expiry || 30 * 24 * 60 * 60 * 1000;
+const expiry = Date.now() + expiryTime;   // treats caller's value as a DURATION
+```
+
+**Read paths** (all treat `expiry` as an absolute timestamp):
+- `cleanupService.ts:228`: `const timeUntilExpiry = region.expiry - currentTime;`
+- `cleanupManagement.ts:29`: `if (region.expiry && region.expiry < now)`
+- `RegionList.ts:103`: `new Date(region.expiry).toLocaleDateString()`
+- `loadAllStoredRegions`: defaults to `Date.now() + 30 days` (a timestamp)
+
+**Impact:** If a caller reads the type doc and passes `expiry: <absolute unix ms>`, `addRegion` stores `Date.now() + <their-timestamp>` — a garbage far-future date. Silent corruption. Dormant today because most callers don't pass `expiry`, but any SDK consumer following the types will hit this.
+
+**Proposed fix:** Make the write side treat `region.expiry` as a timestamp (matching the type doc and all readers). If a caller wants duration-based expiry, they should compute `Date.now() + ms` themselves. Keep the 30-day default behavior when unset.
+
+```ts
+const expiry = region.expiry ?? (Date.now() + 30 * 24 * 60 * 60 * 1000);
+```
+
+**Test needed:** Round-trip test that passes an absolute timestamp and verifies the stored value equals it (not `now + it`).
+
+---
+
+## P1 — `bboxExists` silently drops regions with identical bounds
+
+**Location:** `src/services/regionService.ts:265-280` (in `addRegion`).
+
+```ts
+const bboxExists = styleEntry.regions.some(
+  r => JSON.stringify(r.bounds) === JSON.stringify(region.bounds)
+);
+if (!bboxExists) {
+  // ... persist ...
+  await db.put('styles', styleEntry);
+}
+```
+
+**Impact:** If a user adds two regions on the same style with identical bounds (different `region.id`, different `name`), the second call:
+- Downloads all its tiles (tile keys are `{styleId}:{sourceId}:{z}:{x}:{y}`, not region-scoped, so tiles land in the `tiles` store)
+- Is **silently not persisted** to `styles.regions[]`
+- `downloadRegion` returns `{ regionId: region.id, ... }` suggesting success
+- Later `deleteRegion(region.id)` lookup fails because the region metadata was never written
+
+The caller now has orphan tiles they can't clean up via the public API.
+
+**Proposed fix:** Either
+1. De-dupe by `region.id`, not by bounds. If a region with the same id already exists, update it in place.
+2. Drop the de-dup entirely — the caller provided a unique id, that's their contract.
+3. If the intent is really "don't re-download the same bbox," return an error/warning instead of silently succeeding.
+
+Option 1 feels most correct. Option 2 is simplest.
+
+**Test needed:** Add two regions with identical bounds but different ids; assert both are present in `listStoredRegions()`.
+
+---
+
+## P1 — `deleteStyleResources` `startsWith` collision across style-id prefixes
+
+**Location:** `src/services/regionService.ts:127-179`.
+
+```ts
+// Glyphs
+if (
+  glyphEntry.key.startsWith(`${styleId}:`) ||
+  glyphEntry.key.startsWith(`${styleId}_`) ||
+  glyphEntry.key === styleId
+) {
+  await cursor.delete();
+}
+// Sprites: same pattern
+```
+
+**Impact:** Deleting style `abc` will also delete glyphs/sprites of style `abc_def`, because `"abc_def:fontstack/range".startsWith("abc_")` is true. Cross-style data loss when styleIds share a prefix and the next character is `_`.
+
+**Proposed fix:** Match against an explicit delimiter boundary. Since keys are `{styleId}{delim}…` with `delim ∈ {":", "_"}`:
+```ts
+const key = glyphEntry.key;
+const isMatch =
+  key === styleId ||
+  (key.startsWith(styleId) &&
+   (key[styleId.length] === ':' || key[styleId.length] === '_'));
+```
+
+This still accepts both delimiters but requires a clean boundary. Alternatively, standardize on a single delimiter (`:`) for all resource types (see P2 below).
+
+**Test needed:** Pre-seed glyphs for styles `"abc"` and `"abc_def"`, delete style `"abc"`, assert `"abc_def"`'s glyphs are untouched.
+
+---
+
+## P2 — Font deletion uses narrower prefix match than glyphs/sprites
+
+**Location:** `src/services/regionService.ts:138`.
+
+```ts
+// Fonts - only ":" delimiter
+if (fontEntry.key.startsWith(`${styleId}:`)) { /* delete */ }
+
+// Glyphs/sprites - ":", "_", or exact match
+if (entry.key.startsWith(`${styleId}:`) ||
+    entry.key.startsWith(`${styleId}_`) ||
+    entry.key === styleId) { /* delete */ }
+```
+
+**Impact:** Either fonts miss some legitimate keys that use `_`, or glyphs/sprites are over-eager. Divergent behavior across resource types is a maintainability smell at minimum. Tied to **P1 issue C** — probably resolve together.
+
+**Proposed fix:** Audit the actual key formats emitted by `fontService`, `glyphService`, `spriteService` and standardize on one delimiter. Then apply the boundary-aware match from C across all three.
+
+---
+
+## P2 — UX: glyph progress `total` jumps when real download starts
+
+**Location:** `src/services/regionService.ts:428-434` (in `downloadRegion`).
+
+```ts
+emit('glyphs', 0, ranges.length * fontFamilies.size, 'Downloading glyphs');
+// ... then service's onProgress fires:
+onProgress: (progress) => emit('glyphs', progress.completed, progress.total, ...)
+```
+
+**Impact:** The pre-emit estimates `total = ranges × families`, but the service's actual total may differ. UI progress bar jumps on first real update. Harmless, but visually janky.
+
+**Proposed fix:** Drop the pre-emit — let the service's first `onProgress` event drive the initial state. Or emit with `total: 0` as "starting" sentinel and let UIs handle it as indeterminate.
+
+---
+
+## P2 — `findStyleEntry` secondary-match by `s.key === styleUrl` looks wrong
+
+**Location:** `src/services/regionService.ts:485-490`.
+
+```ts
+return all.find(
+  s => s?.key === region.styleUrl || s?.originalUrl === region.styleUrl
+);
+```
+
+The style `key` is a hash-like identifier, not a URL. Matching it against a URL string should never succeed. But this pattern is copied from existing `isStyleDownloaded` (`styleService.ts:929`), presumably kept for legacy storage rows written before keys were hashes.
+
+**Impact:** Benign dead branch — never matches. Harmless but confusing.
+
+**Proposed fix:** If the legacy case is real, keep it but add a comment explaining. If the legacy case no longer exists in any shipping version, drop the `s.key === styleUrl` check. Check DB version migrations to decide.
+
+---
+
+## Suggested follow-up PR scope
+
+Proposed single PR: **"fix: address audit findings A-D from PR #19"**
+
+1. Fix `expiry` write semantics (P1-A) + add round-trip test.
+2. Fix `bboxExists` de-dup behavior (P1-B) — use id-based replacement + test.
+3. Boundary-aware prefix matching for all resource deletions (P1-C + P2-D) — one shared helper like `resourceKeyBelongsToStyle(key, styleId)`, applied to fonts/glyphs/sprites consistently.
+4. Optional: drop the glyph pre-emit (P2-E) and the dead `key === styleUrl` branch (P2-F).
+
+Estimated size: ~150 lines of src changes + tests.
+
+**Do not start until PR #19 is merged** to avoid rebase churn on overlapping files (especially `regionService.ts`).

--- a/README.md
+++ b/README.md
@@ -285,9 +285,10 @@ The constructor accepts optional service overrides for dependency injection (adv
 
 - `getComprehensiveStorageAnalytics()` - Get detailed storage statistics
 - `getRegionAnalytics()` - Get aggregate analytics across all regions
-- `getTileStatistics(styleId: string)` - Get tile-specific statistics
-- `getFontStatistics(styleId: string)` - Get font statistics
-- `getSpriteStatistics(styleId: string)` - Get sprite statistics
+- `getTileStats(styleId?: string)` - Get tile statistics (optionally filtered by style)
+- `getFontStats()` - Get font statistics
+- `getSpriteStats()` - Get sprite statistics
+- `getGlyphStats()` - Get glyph statistics
 
 **Cleanup & Maintenance Methods:**
 

--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -515,14 +515,6 @@ Load offline styles from IndexedDB. If only one style is stored, it is loaded au
 await control.loadOfflineStyles();
 ```
 
-#### `loadSpecificOfflineStyle(styleId: string): Promise<void>`
-
-Alias for `loadOfflineStyle()`. Loads a specific offline style by ID.
-
-```typescript
-await control.loadSpecificOfflineStyle('style_1234567890');
-```
-
 #### `updateStyleUrl(newStyleUrl: string): void`
 
 Update the style URL used for new region downloads. Also updates the internal region control so subsequent downloads use the new style.

--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -172,17 +172,21 @@ const sizeInBytes = await manager.getRegionSize('my-region');
 console.log(`Region uses ${(sizeInBytes / 1024 / 1024).toFixed(1)} MB`);
 ```
 
-#### `getTileStatistics(styleId: string): Promise<TileStats>`
+#### `getTileStats(styleId?: string): Promise<TileStats>`
 
-Get tile-specific statistics for a given style.
+Get tile statistics. Pass a `styleId` to filter; omit to aggregate across all styles.
 
-#### `getFontStatistics(styleId: string): Promise<EnhancedFontStats>`
+#### `getFontStats(): Promise<EnhancedFontStats>`
 
-Get font statistics for a given style.
+Get font statistics aggregated across all styles.
 
-#### `getSpriteStatistics(styleId: string): Promise<EnhancedSpriteStats>`
+#### `getSpriteStats(): Promise<EnhancedSpriteStats>`
 
-Get sprite statistics for a given style.
+Get sprite statistics aggregated across all styles.
+
+#### `getGlyphStats(): Promise<EnhancedGlyphStats>`
+
+Get glyph statistics aggregated across all styles.
 
 ### Import/Export Methods
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,14 +34,23 @@
  * ```typescript
  * const offlineManager = new OfflineMapManager();
  *
- * await offlineManager.addRegion({
- *   id: 'sf',
- *   name: 'San Francisco',
- *   bounds: [[-122.5, 37.7], [-122.3, 37.9]],
- *   minZoom: 10,
- *   maxZoom: 14,
- *   styleUrl: 'https://api.maptiler.com/maps/streets/style.json?key=YOUR_KEY'
- * });
+ * // downloadRegion runs the full pipeline: style (if missing) → sprites → glyphs → tiles → metadata.
+ * // addRegion on its own only stores metadata; use downloadRegion to actually fetch assets.
+ * await offlineManager.downloadRegion(
+ *   {
+ *     id: 'sf',
+ *     name: 'San Francisco',
+ *     bounds: [[-122.5, 37.7], [-122.3, 37.9]],
+ *     minZoom: 10,
+ *     maxZoom: 14,
+ *     styleUrl: 'https://api.maptiler.com/maps/streets/style.json?key=YOUR_KEY',
+ *   },
+ *   {
+ *     onProgress: ({ phase, completed, total, percentage }) => {
+ *       console.log(`[${phase}] ${completed}/${total} (${percentage.toFixed(1)}%)`);
+ *     },
+ *   }
+ * );
  * ```
  */
 

--- a/src/managers/offlineMapManager/index.ts
+++ b/src/managers/offlineMapManager/index.ts
@@ -4,80 +4,18 @@ import {
   type OfflineManagerServices,
 } from './base';
 import { createOfflineMapManagerModules, type OfflineMapManagerModules } from './modules';
-import type { RegionManagement } from './regionManagement';
-import type { CleanupManagement } from './cleanupManagement';
-import type { ResourceManagement } from './resourceManagement';
-import type { AnalyticsManagement } from './analyticsManagement';
-import type { MaintenanceManagement } from './maintenanceManagement';
-import type { ImportExportManagement } from './importExportManagement';
-import type { StyleManagement } from './styleManagement';
 
-export class OfflineMapManager implements OfflineMapManagerModules {
+// Class/interface declaration merging: this makes every method declared on
+// the module interfaces (RegionManagement, CleanupManagement, ...) available
+// on OfflineMapManager instances at the type level, without re-declaring each
+// one as a `declare public` field. The actual implementations are attached at
+// runtime by the constructor via `Object.assign(this, this.modules)`.
+/* eslint-disable @typescript-eslint/no-empty-object-type, @typescript-eslint/no-unsafe-declaration-merging */
+export interface OfflineMapManager extends OfflineMapManagerModules {}
+
+export class OfflineMapManager {
   private readonly services: OfflineManagerServices;
   private readonly modules: OfflineMapManagerModules;
-
-  // Region management
-  declare public addRegion: RegionManagement['addRegion'];
-  declare public loadRegion: RegionManagement['loadRegion'];
-  declare public deleteRegion: RegionManagement['deleteRegion'];
-  declare public listRegions: RegionManagement['listRegions'];
-  declare public listStoredRegions: RegionManagement['listStoredRegions'];
-  declare public getStoredRegion: RegionManagement['getStoredRegion'];
-
-  // Cleanup management
-  declare public getRegionSize: CleanupManagement['getRegionSize'];
-  declare public cleanupExpiredRegions: CleanupManagement['cleanupExpiredRegions'];
-  declare public forceCleanupExpiredRegions: CleanupManagement['forceCleanupExpiredRegions'];
-  declare public setupAutoCleanup: CleanupManagement['setupAutoCleanup'];
-  declare public stopAutoCleanup: CleanupManagement['stopAutoCleanup'];
-  declare public getRegionAnalytics: CleanupManagement['getRegionAnalytics'];
-  declare public performSmartCleanup: CleanupManagement['performSmartCleanup'];
-  declare public startEnhancedAutoCleanup: CleanupManagement['startEnhancedAutoCleanup'];
-  declare public stopAllAutoCleanup: CleanupManagement['stopAllAutoCleanup'];
-
-  // Resource management
-  declare public downloadTilesWithOptions: ResourceManagement['downloadTilesWithOptions'];
-  declare public getTileStatistics: ResourceManagement['getTileStatistics'];
-  declare public downloadFontsWithOptions: ResourceManagement['downloadFontsWithOptions'];
-  declare public getFontStatistics: ResourceManagement['getFontStatistics'];
-  declare public getFontAnalytics: ResourceManagement['getFontAnalytics'];
-  declare public cleanupOldFonts: ResourceManagement['cleanupOldFonts'];
-  declare public verifyAndRepairFonts: ResourceManagement['verifyAndRepairFonts'];
-  declare public downloadSpritesWithOptions: ResourceManagement['downloadSpritesWithOptions'];
-  declare public getSpriteStatistics: ResourceManagement['getSpriteStatistics'];
-  declare public cleanupOldSprites: ResourceManagement['cleanupOldSprites'];
-  declare public verifyAndRepairSprites: ResourceManagement['verifyAndRepairSprites'];
-  declare public getSpriteAnalytics: ResourceManagement['getSpriteAnalytics'];
-  declare public downloadGlyphsWithOptions: ResourceManagement['downloadGlyphsWithOptions'];
-  declare public getGlyphStatistics: ResourceManagement['getGlyphStatistics'];
-  declare public getGlyphAnalytics: ResourceManagement['getGlyphAnalytics'];
-  declare public loadGlyphsForStyle: ResourceManagement['loadGlyphsForStyle'];
-  declare public cleanupOldGlyphs: ResourceManagement['cleanupOldGlyphs'];
-  declare public verifyAndRepairGlyphs: ResourceManagement['verifyAndRepairGlyphs'];
-
-  // Analytics management
-  declare public getComprehensiveStorageAnalytics: AnalyticsManagement['getComprehensiveStorageAnalytics'];
-
-  // Maintenance management
-  declare public performCompleteMaintenance: MaintenanceManagement['performCompleteMaintenance'];
-
-  // Import/export management
-  declare public exportRegionAsJSON: ImportExportManagement['exportRegionAsJSON'];
-  declare public exportRegionAsPMTiles: ImportExportManagement['exportRegionAsPMTiles'];
-  declare public exportRegionAsMBTiles: ImportExportManagement['exportRegionAsMBTiles'];
-  declare public importRegion: ImportExportManagement['importRegion'];
-  declare public downloadExportedRegion: ImportExportManagement['downloadExportedRegion'];
-
-  // Style management
-  declare public downloadStyle: StyleManagement['downloadStyle'];
-  declare public loadStyleById: StyleManagement['loadStyleById'];
-  declare public listStyles: StyleManagement['listStyles'];
-  declare public deleteStyle: StyleManagement['deleteStyle'];
-  declare public getStyleStats: StyleManagement['getStyleStats'];
-  declare public downloadMapboxStyle: StyleManagement['downloadMapboxStyle'];
-  declare public downloadMapLibreStyle: StyleManagement['downloadMapLibreStyle'];
-  declare public downloadStyleWithAutoDetection: StyleManagement['downloadStyleWithAutoDetection'];
-  declare public cleanupOldStyles: StyleManagement['cleanupOldStyles'];
 
   constructor(overrides: OfflineManagerServiceOverrides = {}) {
     this.services = createManagerServices(overrides);

--- a/src/managers/offlineMapManager/regionManagement.ts
+++ b/src/managers/offlineMapManager/regionManagement.ts
@@ -1,9 +1,21 @@
-import type { OfflineRegionOptions, StoredRegion } from '@/types';
+import type {
+  DownloadRegionOptions,
+  DownloadRegionResult,
+  OfflineRegionOptions,
+  StoredRegion,
+} from '@/types';
 import type { OfflineManagerServices } from './base';
 
 export interface RegionManagement {
   addRegion(region: OfflineRegionOptions): Promise<void>;
-  loadRegion(region: OfflineRegionOptions): Promise<void>;
+  downloadRegion(
+    region: OfflineRegionOptions,
+    options?: DownloadRegionOptions
+  ): Promise<DownloadRegionResult>;
+  loadRegion(
+    region: OfflineRegionOptions,
+    options?: DownloadRegionOptions
+  ): Promise<DownloadRegionResult>;
   deleteRegion(regionId: string): Promise<void>;
   listRegions(): Promise<OfflineRegionOptions[]>;
   listStoredRegions(): Promise<StoredRegion[]>;
@@ -12,7 +24,10 @@ export interface RegionManagement {
 
 export const createRegionManagement = (services: OfflineManagerServices): RegionManagement => ({
   addRegion: async (region: OfflineRegionOptions) => services.regionService.addRegion(region),
-  loadRegion: async (region: OfflineRegionOptions) => services.regionService.loadRegion(region),
+  downloadRegion: async (region: OfflineRegionOptions, options?: DownloadRegionOptions) =>
+    services.regionService.downloadRegion(region, options),
+  loadRegion: async (region: OfflineRegionOptions, options?: DownloadRegionOptions) =>
+    services.regionService.loadRegion(region, options),
   deleteRegion: async (regionId: string) => services.regionService.deleteRegion(regionId),
   listRegions: async () => services.regionService.listRegions(),
   listStoredRegions: async () => services.regionService.listStoredRegions(),

--- a/src/managers/offlineMapManager/resourceManagement.ts
+++ b/src/managers/offlineMapManager/resourceManagement.ts
@@ -5,19 +5,19 @@ export type ResourceServiceMethod<TMethod extends keyof ResourceService> = Resou
 
 export interface ResourceManagement {
   downloadTilesWithOptions: ResourceService['downloadTilesWithOptions'];
-  getTileStatistics: ResourceService['getTileStatistics'];
+  getTileStats: ResourceService['getTileStats'];
   downloadFontsWithOptions: ResourceService['downloadFontsWithOptions'];
-  getFontStatistics: ResourceService['getFontStatistics'];
+  getFontStats: ResourceService['getFontStats'];
   getFontAnalytics: ResourceService['getFontAnalytics'];
   cleanupOldFonts: ResourceService['cleanupOldFonts'];
   verifyAndRepairFonts: ResourceService['verifyAndRepairFonts'];
   downloadSpritesWithOptions: ResourceService['downloadSpritesWithOptions'];
-  getSpriteStatistics: ResourceService['getSpriteStatistics'];
+  getSpriteStats: ResourceService['getSpriteStats'];
   cleanupOldSprites: ResourceService['cleanupOldSprites'];
   verifyAndRepairSprites: ResourceService['verifyAndRepairSprites'];
   getSpriteAnalytics: ResourceService['getSpriteAnalytics'];
   downloadGlyphsWithOptions: ResourceService['downloadGlyphsWithOptions'];
-  getGlyphStatistics: ResourceService['getGlyphStatistics'];
+  getGlyphStats: ResourceService['getGlyphStats'];
   getGlyphAnalytics: ResourceService['getGlyphAnalytics'];
   loadGlyphsForStyle: ResourceService['loadGlyphsForStyle'];
   cleanupOldGlyphs: ResourceService['cleanupOldGlyphs'];
@@ -26,21 +26,21 @@ export interface ResourceManagement {
 
 export const createResourceManagement = (services: OfflineManagerServices): ResourceManagement => ({
   downloadTilesWithOptions: (...args) => services.resourceService.downloadTilesWithOptions(...args),
-  getTileStatistics: (...args) => services.resourceService.getTileStatistics(...args),
+  getTileStats: (...args) => services.resourceService.getTileStats(...args),
   downloadFontsWithOptions: (...args) => services.resourceService.downloadFontsWithOptions(...args),
-  getFontStatistics: (...args) => services.resourceService.getFontStatistics(...args),
+  getFontStats: (...args) => services.resourceService.getFontStats(...args),
   getFontAnalytics: (...args) => services.resourceService.getFontAnalytics(...args),
   cleanupOldFonts: (...args) => services.resourceService.cleanupOldFonts(...args),
   verifyAndRepairFonts: (...args) => services.resourceService.verifyAndRepairFonts(...args),
   downloadSpritesWithOptions: (...args) =>
     services.resourceService.downloadSpritesWithOptions(...args),
-  getSpriteStatistics: (...args) => services.resourceService.getSpriteStatistics(...args),
+  getSpriteStats: (...args) => services.resourceService.getSpriteStats(...args),
   cleanupOldSprites: (...args) => services.resourceService.cleanupOldSprites(...args),
   verifyAndRepairSprites: (...args) => services.resourceService.verifyAndRepairSprites(...args),
   getSpriteAnalytics: (...args) => services.resourceService.getSpriteAnalytics(...args),
   downloadGlyphsWithOptions: (...args) =>
     services.resourceService.downloadGlyphsWithOptions(...args),
-  getGlyphStatistics: (...args) => services.resourceService.getGlyphStatistics(...args),
+  getGlyphStats: (...args) => services.resourceService.getGlyphStats(...args),
   getGlyphAnalytics: (...args) => services.resourceService.getGlyphAnalytics(...args),
   loadGlyphsForStyle: (...args) => services.resourceService.loadGlyphsForStyle(...args),
   cleanupOldGlyphs: (...args) => services.resourceService.cleanupOldGlyphs(...args),

--- a/src/services/analyticsService.ts
+++ b/src/services/analyticsService.ts
@@ -1,107 +1,33 @@
-import { dbPromise } from '@/storage/indexedDbManager';
 import { getTileStats } from './tileService';
-import { getFontAnalytics } from './fontService';
-import { getSpriteAnalytics } from './spriteService';
+import { getFontStats } from './fontService';
+import { getSpriteStats } from './spriteService';
 import { getGlyphStats, EnhancedGlyphStats } from './glyphService';
 import type {
   RegionAnalytics,
-  StyleEntry,
   TileStats,
   StorageAnalyticsReport,
   EnhancedFontStats,
   EnhancedSpriteStats,
 } from '@/types';
 
+// The underlying stats functions already iterate every entry in their
+// respective stores, so the "getAll*" methods are just readable aliases
+// — one scan per store, no per-style sub-iteration.
 export class AnalyticsService {
   async getAllTileStats(): Promise<TileStats> {
-    const db = await dbPromise;
-    const styles = await db.getAll('styles');
-
-    let totalCount = 0;
-    let totalSize = 0;
-    const combinedZoomStats = new Map<number, { count: number; size: number }>();
-    let oldestTile: Date | undefined;
-    let newestTile: Date | undefined;
-
-    for (const style of styles) {
-      const styleStats = await getTileStats((style as StyleEntry).key);
-      totalCount += styleStats.count || 0;
-      totalSize += styleStats.totalSize || 0;
-
-      // Track oldest/newest across all styles
-      if (styleStats.oldestTile && (!oldestTile || styleStats.oldestTile < oldestTile)) {
-        oldestTile = styleStats.oldestTile;
-      }
-      if (styleStats.newestTile && (!newestTile || styleStats.newestTile > newestTile)) {
-        newestTile = styleStats.newestTile;
-      }
-
-      // Combine zoom level statistics
-      if (styleStats.zoomLevelStats) {
-        styleStats.zoomLevelStats.forEach((stats, zoom) => {
-          const existing = combinedZoomStats.get(zoom) || { count: 0, size: 0 };
-          combinedZoomStats.set(zoom, {
-            count: existing.count + stats.count,
-            size: existing.size + stats.size,
-          });
-        });
-      }
-    }
-
-    return {
-      count: totalCount,
-      totalSize,
-      averageSize: totalCount > 0 ? totalSize / totalCount : 0,
-      oldestTile,
-      newestTile,
-      zoomLevelStats: combinedZoomStats,
-    };
+    return getTileStats();
   }
 
   async getAllFontStats(): Promise<EnhancedFontStats> {
-    const analytics = await getFontAnalytics();
-    // Access the nested properties from analytics
-    const basic = analytics.basic as { totalFonts: number; totalSize: number; averageSize: number };
-    const distribution = analytics.distribution as Record<string, number>;
-
-    return {
-      count: basic.totalFonts,
-      totalSize: basic.totalSize,
-      averageSize: basic.averageSize,
-      fonts: [],
-      fontsByType: distribution,
-      corruptedFonts: [],
-    };
+    return getFontStats();
   }
 
   async getAllSpriteStats(): Promise<EnhancedSpriteStats> {
-    const analytics = await getSpriteAnalytics();
-    // Access the nested properties from analytics
-    const basic = analytics.basic as {
-      totalSprites: number;
-      totalSize: number;
-      averageSize: number;
-    };
-    const distribution = analytics.distribution as {
-      spritesByType: Record<string, number>;
-      sizeByType: Record<string, number>;
-    };
-
-    return {
-      count: basic.totalSprites,
-      totalSize: basic.totalSize,
-      averageSize: basic.totalSize / Math.max(basic.totalSprites, 1),
-      sprites: [],
-      spritesByType: distribution.spritesByType,
-      sizeByType: distribution.sizeByType,
-      corruptedSprites: [],
-    };
+    return getSpriteStats();
   }
 
   async getAllGlyphStats(): Promise<EnhancedGlyphStats> {
-    // Since getGlyphStats() operates globally and doesn't take parameters,
-    // we can just call it directly instead of iterating through styles
-    return await getGlyphStats();
+    return getGlyphStats();
   }
 
   async getComprehensiveStorageAnalytics(

--- a/src/services/cleanupService.ts
+++ b/src/services/cleanupService.ts
@@ -1,6 +1,7 @@
 import { dbPromise } from '@/storage/indexedDbManager';
 import { logger } from '@/utils';
 import { parseTileKey } from '@/utils/tileKey';
+import { loadAllStoredRegions } from '@/services/regionService';
 import type { StoredRegion, RegionCleanupOptions, CleanupResult, RegionAnalytics } from '@/types';
 
 const cleanupLogger = logger.scope('CleanupService');
@@ -372,43 +373,7 @@ export class CleanupService {
   }
 
   async getAllRegions(): Promise<StoredRegion[]> {
-    const db = await this.db;
-    const allRegions: StoredRegion[] = [];
-
-    // Regions are stored inside styles.regions[], not in a separate regions table
-    const styles = await db.getAll('styles');
-    for (const style of styles) {
-      const styleEntry = style as {
-        key?: string;
-        regions?: Array<{
-          id?: string;
-          name?: string;
-          bounds?: [[number, number], [number, number]];
-          minZoom?: number;
-          maxZoom?: number;
-          styleUrl?: string;
-          created?: number;
-          updated?: number;
-          expiry?: number;
-        }>;
-      };
-      if (styleEntry.regions && Array.isArray(styleEntry.regions)) {
-        const regionsWithStyle = styleEntry.regions.map(
-          region =>
-            ({
-              ...region,
-              key: region.id,
-              styleId: styleEntry.key,
-              created: region.created || Date.now(),
-              lastModified: region.updated || region.created || Date.now(),
-              expiry: region.expiry || Date.now() + 30 * 24 * 60 * 60 * 1000,
-            }) as StoredRegion
-        );
-        allRegions.push(...regionsWithStyle);
-      }
-    }
-
-    return allRegions;
+    return loadAllStoredRegions();
   }
 
   async getRegionSize(regionId: string, styleIdParam?: string): Promise<number> {

--- a/src/services/regionService.ts
+++ b/src/services/regionService.ts
@@ -581,49 +581,44 @@ export class RegionService {
   }
 
   async listRegions(): Promise<OfflineRegionOptions[]> {
-    // Regions are stored inside styles.regions[], not in a separate regions table
-    const styles = await loadStyles();
-    const allRegions: OfflineRegionOptions[] = [];
-
-    for (const style of styles) {
-      if (style.regions && Array.isArray(style.regions)) {
-        allRegions.push(...(style.regions as OfflineRegionOptions[]));
-      }
-    }
-
-    return allRegions;
+    // StoredRegion extends OfflineRegionOptions; no need for a second iteration.
+    return this.listStoredRegions();
   }
 
   /**
    * List all stored regions from styles (used for UI and fitBounds)
    */
   async listStoredRegions(): Promise<StoredRegion[]> {
-    try {
-      const styles = await loadStyles();
-      const allRegions: StoredRegion[] = [];
-      for (const style of styles) {
-        if (style.regions && Array.isArray(style.regions)) {
-          const regionsWithStyle = style.regions.map(
-            region =>
-              ({
-                ...region,
-                key: region.id,
-                styleId: style.key,
-                created: region.created || Date.now(),
-                lastModified: region.updated || region.created || Date.now(),
-                expiry: region.expiry || Date.now() + 30 * 24 * 60 * 60 * 1000,
-              }) as StoredRegion
-          );
-          allRegions.push(...regionsWithStyle);
-        }
+    return loadAllStoredRegions();
+  }
+}
+
+/**
+ * Flatten every `styles.regions[]` entry into a `StoredRegion[]` with the
+ * backing style's id, plus defaults for `created`/`lastModified`/`expiry`.
+ * Shared by `RegionService.listStoredRegions` and `CleanupService.getAllRegions`.
+ */
+export async function loadAllStoredRegions(): Promise<StoredRegion[]> {
+  try {
+    const styles = await loadStyles();
+    const allRegions: StoredRegion[] = [];
+    for (const style of styles) {
+      if (!style.regions || !Array.isArray(style.regions)) continue;
+      for (const region of style.regions) {
+        allRegions.push({
+          ...region,
+          key: region.id,
+          styleId: style.key,
+          created: region.created || Date.now(),
+          lastModified: region.updated || region.created || Date.now(),
+          expiry: region.expiry || Date.now() + 30 * 24 * 60 * 60 * 1000,
+        } as StoredRegion);
       }
-      regionLogger.debug('Extracted regions from styles:', allRegions);
-      return allRegions;
-    } catch (error) {
-      regionLogger.error('Error loading regions from styles:', error);
-      // Fallback to cleanup service method if available
-      // return this.cleanupService.getAllRegions();
-      return [];
     }
+    regionLogger.debug('Extracted regions from styles:', allRegions);
+    return allRegions;
+  } catch (error) {
+    regionLogger.error('Error loading regions from styles:', error);
+    return [];
   }
 }

--- a/src/services/regionService.ts
+++ b/src/services/regionService.ts
@@ -1,11 +1,23 @@
 import { dbPromise } from '@/storage/indexedDbManager';
-import { patchStyleForOffline } from '@/utils/styleUtils';
+import {
+  extractAllFontNames,
+  normalizeSpriteProperty,
+  patchStyleForOffline,
+} from '@/utils/styleUtils';
 import { logger } from '@/utils/logger';
 import { parseTileKey } from '@/utils/tileKey';
+import { GLYPH_CONFIG } from '@/utils/constants';
+import { isMapboxProtocol, resolveMapboxUrl } from '@/utils/styleProviderUtils';
 import { loadStyles } from '@/services/styleService';
-import type { OfflineRegionOptions, StoredRegion } from '@/types/region';
-import type { StyleEntry } from '@/types/style';
-import type { TileEntry } from '@/types';
+import type {
+  DownloadRegionOptions,
+  DownloadRegionProgress,
+  DownloadRegionResult,
+  OfflineRegionOptions,
+  StoredRegion,
+} from '@/types/region';
+import type { BaseStyle, StyleEntry } from '@/types/style';
+import type { SpriteDownloadResult, TileEntry } from '@/types';
 import * as tilebelt from '@mapbox/tilebelt';
 
 const regionLogger = logger.scope('RegionService');
@@ -268,21 +280,214 @@ export class RegionService {
     }
   }
 
-  async loadRegion(region: OfflineRegionOptions): Promise<void> {
-    const styleId = region.styleId || region.id;
-    if (!styleId) {
-      throw new Error(`No style ID found for region: ${region.id}`);
+  async loadRegion(
+    region: OfflineRegionOptions,
+    options: DownloadRegionOptions = {}
+  ): Promise<DownloadRegionResult> {
+    return this.downloadRegion(region, options);
+  }
+
+  /**
+   * Download everything an offline region needs — style (if missing), sprites, glyphs,
+   * tiles — and then persist region metadata. This is the programmatic equivalent of the
+   * UI control's "Download region" flow.
+   */
+  async downloadRegion(
+    region: OfflineRegionOptions,
+    options: DownloadRegionOptions = {}
+  ): Promise<DownloadRegionResult> {
+    if (!region.styleUrl) {
+      throw new Error('Region must have a styleUrl');
     }
+
+    const {
+      onProgress,
+      provider = 'auto',
+      accessToken,
+      skipGlyphs = false,
+      skipSprites = false,
+      glyphRanges,
+      tileOptions,
+    } = options;
+
+    const emit = (
+      phase: DownloadRegionProgress['phase'],
+      completed: number,
+      total: number,
+      message?: string
+    ) => {
+      if (!onProgress) return;
+      const safeTotal = total > 0 ? total : 1;
+      const clamped = Math.min(completed, safeTotal);
+      onProgress({
+        phase,
+        completed: clamped,
+        total: safeTotal,
+        percentage: (clamped / safeTotal) * 100,
+        message,
+      });
+    };
+
+    // 1. Ensure style is downloaded
+    let styleResult: DownloadRegionResult['styleResult'];
+    let styleId: string;
+    let styleEntry = await this.findStyleEntry(region);
+
+    if (!styleEntry) {
+      regionLogger.debug(`Style not found locally, downloading: ${region.styleUrl}`);
+      const { downloadStyleWithProvider } = await import('@/services/styleService');
+      emit('style', 0, 100, 'Downloading style');
+      styleResult = await downloadStyleWithProvider(region.styleUrl, {
+        provider,
+        accessToken,
+        skipExisting: true,
+        enableSourceEmbedding: true,
+        onProgress: progress => emit('style', progress.percentage ?? 0, 100, 'Downloading style'),
+      });
+      if (!styleResult.success) {
+        throw new Error(`Failed to download style: ${styleResult.errors.join(', ')}`);
+      }
+      styleId = styleResult.styleId;
+      styleEntry = await (await dbPromise).get('styles', styleId);
+      if (!styleEntry) {
+        throw new Error(`Style entry missing after download: ${styleId}`);
+      }
+    } else {
+      styleId = styleEntry.key;
+    }
+    emit('style', 100, 100, 'Style ready');
+
+    // Capture original (pre-patch) resource URLs for sprite/glyph downloads
+    const storedStyle = styleEntry.style as BaseStyle;
+    const storedTokenCandidate = (styleEntry as Record<string, unknown>).accessToken;
+    const effectiveAccessToken =
+      accessToken ?? (typeof storedTokenCandidate === 'string' ? storedTokenCandidate : undefined);
+    const originalSpriteUrl = (styleEntry.originalSpriteUrl ??
+      storedStyle.sprite) as BaseStyle['sprite'];
+    const originalGlyphsUrl = styleEntry.originalGlyphsUrl ?? storedStyle.glyphs;
+
+    // 2. Sprites
+    const spriteResults: SpriteDownloadResult[] = [];
+    if (!skipSprites) {
+      const spriteSources = normalizeSpriteProperty(originalSpriteUrl);
+      if (spriteSources.length > 0) {
+        const { downloadSprites } = await import('@/services/spriteService');
+        const suffixes = ['.json', '.png', '@2x.json', '@2x.png'];
+        const totalFiles = spriteSources.length * suffixes.length;
+        let completed = 0;
+        emit('sprites', 0, totalFiles, 'Downloading sprites');
+
+        for (const source of spriteSources) {
+          let spriteBase = source.url;
+          if (isMapboxProtocol(spriteBase) && effectiveAccessToken) {
+            spriteBase = resolveMapboxUrl(spriteBase, effectiveAccessToken);
+          }
+          const qIndex = spriteBase.indexOf('?');
+          const spriteUrls = suffixes.map(suffix =>
+            qIndex !== -1
+              ? spriteBase.slice(0, qIndex) + suffix + spriteBase.slice(qIndex)
+              : spriteBase + suffix
+          );
+          try {
+            const result = await downloadSprites(spriteUrls, styleId, {
+              enableValidation: true,
+              skipExisting: false,
+              namePrefix: source.id !== 'sprite' ? source.id : undefined,
+              onProgress: (progress: { completed: number; total: number }) => {
+                emit('sprites', completed + progress.completed, totalFiles, 'Downloading sprites');
+              },
+            });
+            spriteResults.push(result);
+          } catch (error) {
+            regionLogger.warn(`Sprite download failed for source ${source.id} (non-fatal):`, error);
+          }
+          completed += suffixes.length;
+          emit('sprites', completed, totalFiles, 'Downloading sprites');
+        }
+      }
+    }
+
+    // 3. Glyphs
+    let glyphResult: DownloadRegionResult['glyphResult'];
+    if (!skipGlyphs && originalGlyphsUrl && !originalGlyphsUrl.startsWith('idb://')) {
+      const fontFamilies = new Set(
+        extractAllFontNames(
+          storedStyle as unknown as {
+            layers?: Array<{ layout?: { [key: string]: unknown } }>;
+            schema?: Record<string, { default?: unknown }>;
+          }
+        )
+      );
+      if (fontFamilies.size > 0) {
+        const { downloadGlyphs } = await import('@/services/glyphService');
+        let glyphsUrl = originalGlyphsUrl;
+        if (isMapboxProtocol(glyphsUrl) && effectiveAccessToken) {
+          glyphsUrl = resolveMapboxUrl(glyphsUrl, effectiveAccessToken);
+        }
+        const ranges = glyphRanges ?? [...GLYPH_CONFIG.COMPREHENSIVE_RANGES];
+        emit('glyphs', 0, ranges.length * fontFamilies.size, 'Downloading glyphs');
+        try {
+          glyphResult = await downloadGlyphs(glyphsUrl, Array.from(fontFamilies), styleId, ranges, {
+            onProgress: (progress: { completed: number; total: number }) => {
+              emit('glyphs', progress.completed, progress.total, 'Downloading glyphs');
+            },
+          });
+        } catch (error) {
+          regionLogger.warn('Glyph download failed (non-fatal):', error);
+        }
+      }
+    }
+
+    // 4. Tiles — use the stored (source-embedded) style, which still has HTTP tile URLs
+    const { downloadTiles } = await import('@/services/tileService');
+    const regionForTiles = { ...region, styleId };
+    emit('tiles', 0, 100, 'Downloading tiles');
+    const tileResult = await downloadTiles(regionForTiles, storedStyle, styleId, {
+      skipExisting: false,
+      batchSize: 20,
+      ...tileOptions,
+      onProgress: progress => {
+        emit('tiles', progress.completed, progress.total, progress.message ?? 'Downloading tiles');
+        tileOptions?.onProgress?.(progress);
+      },
+    });
+
+    // 5. Metadata — must run last, since addRegion patches style URLs to idb://
+    emit('metadata', 0, 1, 'Saving region metadata');
+    await this.addRegion({
+      ...region,
+      styleId,
+      tileExtension: region.tileExtension ?? tileResult.tileExtension,
+    });
+    emit('metadata', 1, 1, 'Region ready');
+
+    return {
+      regionId: region.id,
+      styleId,
+      styleResult,
+      spriteResults,
+      glyphResult,
+      tileResult,
+    };
+  }
+
+  /**
+   * Look up the stored style matching a region — by `styleId` first, then `styleUrl`.
+   */
+  private async findStyleEntry(region: OfflineRegionOptions): Promise<StyleEntry | undefined> {
     const db = await dbPromise;
-    const storedStyle = await db.get('styles', styleId);
-
-    if (!storedStyle || !('style' in storedStyle)) {
-      throw new Error(`Style not found for region: ${region.id}`);
+    if (region.styleId) {
+      const byId = await db.get('styles', region.styleId);
+      if (byId) return byId;
     }
-
-    // TODO: Implement loadTiles function in tileService
-    // await loadTiles(region, styleId);
-    regionLogger.warn('loadTiles function not yet implemented');
+    if (region.styleUrl) {
+      const all = await db.getAll('styles');
+      return all.find(
+        (s: Record<string, unknown> & { key?: string; originalUrl?: string }) =>
+          s?.key === region.styleUrl || s?.originalUrl === region.styleUrl
+      );
+    }
+    return undefined;
   }
 
   async deleteRegion(regionId: string): Promise<void> {

--- a/src/services/regionService.ts
+++ b/src/services/regionService.ts
@@ -452,13 +452,15 @@ export class RegionService {
       },
     });
 
-    // 5. Metadata — must run last, since addRegion patches style URLs to idb://
+    // 5. Metadata — must run last, since addRegion patches style URLs to idb://.
+    // Do NOT auto-fill tileExtension from tileResult: that's only the first
+    // source's extension, and addRegion feeds it to patchStyleForOffline which
+    // would override ALL sources — breaking mixed raster+vector styles. The
+    // patcher extracts per-source extensions from tile URL patterns when
+    // tileExtension is undefined. Callers who need to force an extension can
+    // still pass `region.tileExtension` explicitly.
     emit('metadata', 0, 1, 'Saving region metadata');
-    await this.addRegion({
-      ...region,
-      styleId,
-      tileExtension: region.tileExtension ?? tileResult.tileExtension,
-    });
+    await this.addRegion({ ...region, styleId });
     emit('metadata', 1, 1, 'Region ready');
 
     return {

--- a/src/services/resourceService.ts
+++ b/src/services/resourceService.ts
@@ -49,7 +49,7 @@ export class ResourceService {
     return downloadTiles(region, style, styleId, options);
   }
 
-  async getTileStatistics(styleId?: string): Promise<TileStats> {
+  async getTileStats(styleId?: string): Promise<TileStats> {
     return getTileStats(styleId);
   }
 
@@ -70,7 +70,7 @@ export class ResourceService {
     return downloadFonts(fontUrls, downloadId, options);
   }
 
-  async getFontStatistics(): Promise<EnhancedFontStats> {
+  async getFontStats(): Promise<EnhancedFontStats> {
     return getFontStats();
   }
 
@@ -96,7 +96,7 @@ export class ResourceService {
     return downloadSprites(spriteUrls, styleName, options);
   }
 
-  async getSpriteStatistics(): Promise<EnhancedSpriteStats> {
+  async getSpriteStats(): Promise<EnhancedSpriteStats> {
     return getSpriteStats();
   }
 
@@ -124,7 +124,7 @@ export class ResourceService {
     return downloadGlyphs(glyphUrl, fontstacks, styleName, ranges, options);
   }
 
-  async getGlyphStatistics(): Promise<EnhancedGlyphStats> {
+  async getGlyphStats(): Promise<EnhancedGlyphStats> {
     return getGlyphStats();
   }
 

--- a/src/types/region.ts
+++ b/src/types/region.ts
@@ -1,3 +1,57 @@
+import type { StyleProvider } from './style';
+import type { TileDownloadOptions, TileDownloadResult } from './tile';
+import type { SpriteDownloadResult } from './sprite';
+import type { GlyphDownloadResult } from './glyph';
+import type { StyleDownloadResult } from './style';
+
+/**
+ * Phase of a region download pipeline, reported via `DownloadRegionOptions.onProgress`.
+ */
+export type DownloadRegionPhase = 'style' | 'sprites' | 'glyphs' | 'tiles' | 'metadata';
+
+/**
+ * Progress update emitted by `OfflineMapManager.downloadRegion`.
+ */
+export interface DownloadRegionProgress {
+  phase: DownloadRegionPhase;
+  completed: number;
+  total: number;
+  percentage: number;
+  message?: string;
+}
+
+/**
+ * Options for the programmatic `downloadRegion` pipeline.
+ */
+export interface DownloadRegionOptions {
+  /** Called with per-phase progress during style → sprites → glyphs → tiles → metadata. */
+  onProgress?: (progress: DownloadRegionProgress) => void;
+  /** Style provider hint when the style needs to be fetched. Defaults to 'auto'. */
+  provider?: StyleProvider;
+  /** Mapbox access token; required when the style or sources use mapbox:// URLs. */
+  accessToken?: string;
+  /** Skip glyph download entirely. Default: false. */
+  skipGlyphs?: boolean;
+  /** Skip sprite download entirely. Default: false. */
+  skipSprites?: boolean;
+  /** Override Unicode glyph ranges fetched per font. Defaults to `GLYPH_CONFIG.COMPREHENSIVE_RANGES`. */
+  glyphRanges?: string[];
+  /** Extra options forwarded to the tile download step. */
+  tileOptions?: TileDownloadOptions;
+}
+
+/**
+ * Result of a full `downloadRegion` pipeline.
+ */
+export interface DownloadRegionResult {
+  regionId: string;
+  styleId: string;
+  styleResult?: StyleDownloadResult;
+  spriteResults: SpriteDownloadResult[];
+  glyphResult?: GlyphDownloadResult;
+  tileResult: TileDownloadResult;
+}
+
 /**
  * Stored region with metadata
  * Extends OfflineRegionOptions with database-specific fields

--- a/src/ui/managers/downloadManager.ts
+++ b/src/ui/managers/downloadManager.ts
@@ -44,13 +44,9 @@
  * @module downloadManager
  */
 
-import { isStyleDownloaded, loadStyles } from '@/services/styleService';
-import { downloadTiles } from '@/services/tileService';
 import { OfflineMapManager } from '@/managers/offlineMapManager';
 import { RegionFormData } from '@/ui/modals/regionFormModal';
 import { logger } from '@/utils/logger';
-import { isMapboxProtocol, resolveMapboxUrl } from '@/utils/styleProviderUtils';
-import { extractAllFontNames } from '@/utils/styleUtils';
 
 const downloadLogger = logger.scope('DownloadManager');
 
@@ -198,362 +194,29 @@ export class DownloadManager {
     };
 
     const regionId = regionConfig.id;
+    this.updateUIForDownloadStart();
 
     try {
-      // Check if style is downloaded (by styleUrl only)
-      const styleExists = await isStyleDownloaded(undefined, regionConfig.styleUrl);
-
-      let finalStyleId: string;
-      if (!styleExists) {
-        // Enhanced style download with Mapbox GL support
-        downloadLogger.debug(`Downloading style with provider: ${formData.provider}`);
-
-        // Use the enhanced downloadStyleWithProvider for Mapbox GL support
-        const styleDownloadOptions = {
-          skipExisting: true,
-          enableSourceEmbedding: true, // CRITICAL: Embed TileJSON into sources for tile downloads
-          provider: formData.provider || 'auto',
-          accessToken: formData.accessToken,
-          onProgress: (progress: { percentage?: number }) => {
-            downloadLogger.debug(`Style download progress: ${progress.percentage}%`);
-            this.updateProgress(
-              regionId,
-              regionConfig.name,
-              'style',
-              progress.percentage || 0,
-              100,
-              'Downloading style'
-            );
-          },
-        };
-
-        const styleResult = await this.offlineManager.downloadStyle(
-          regionConfig.styleUrl,
-          styleDownloadOptions
-        );
-
-        if (!styleResult.success) {
-          throw new Error(`Failed to download style: ${styleResult.errors.join(', ')}`);
-        }
-
-        finalStyleId = styleResult.styleId;
-        downloadLogger.debug(`Style downloaded successfully: ${finalStyleId}`);
-      } else {
-        // Find the existing style to get its ID
-        const styles = await loadStyles();
-        const existingStyle = styles.find(s => {
-          const sprite = s?.style?.sprite;
-          const spriteMatch = typeof sprite === 'string' && sprite.includes(regionConfig.styleUrl);
-          return spriteMatch || s?.originalUrl === regionConfig.styleUrl;
-        });
-        if (!existingStyle) {
-          throw new Error('Style exists but could not be found');
-        }
-        finalStyleId = existingStyle.key;
-        downloadLogger.debug(`Using existing style: ${finalStyleId}`);
-      }
-
-      // Update region config with the styleId from the downloaded/existing style
-      const finalRegionConfig = {
-        ...regionConfig,
-        styleId: finalStyleId,
-      };
-
-      // Update UI to show download starting
-      this.updateUIForDownloadStart();
-
-      // IMPORTANT: Get the style data BEFORE calling addRegion(), which patches URLs to idb://
-      // We need the original HTTP URLs for downloading resources
-      const styles = await loadStyles();
-      const styleData = styles.find((s: { key?: string }) => s.key === finalStyleId);
-      if (!styleData) {
-        throw new Error('Style not found for resource download');
-      }
-
-      // Get the stored style which has embedded TileJSON data
-      // This is the style we'll use for tile downloads (it has the tiles array)
-      // MUST be loaded before addRegion() patches the URLs
-      const styleWithEmbeddedSources = styleData.style;
-
-      // Use original sprite/glyph URLs stored in the style metadata
-      // These are preserved from when the style was first downloaded
-      const originalSpriteUrl = styleData.originalSpriteUrl;
-      const originalGlyphsUrl = styleData.originalGlyphsUrl;
-
-      downloadLogger.debug('Original URLs from style metadata:', {
-        sprite: originalSpriteUrl,
-        glyphs: originalGlyphsUrl,
-      });
-
-      // Create a copy of the style with original URLs for resource downloads
-      const originalStyleForResources = {
-        ...styleData.style,
-        sprite: originalSpriteUrl,
-        glyphs: originalGlyphsUrl,
-      };
-
-      // Download sprites if the style has them
-      // Supports both string format ("https://...") and array format ([{id, url}, ...])
-      const rawSprite = originalStyleForResources?.sprite;
-      const spriteSources = this.normalizeSpriteProperty(rawSprite);
-
-      if (spriteSources.length > 0) {
-        downloadLogger.debug(
-          `Downloading sprites for style: ${finalStyleId} (${spriteSources.length} source(s))`
-        );
-        try {
-          const { SpriteService } = await import('@/services/spriteService');
-          const spriteService = new SpriteService();
-          const suffixes = ['.json', '.png', '@2x.json', '@2x.png'];
-
-          let totalSpriteFiles = 0;
-          let completedSpriteFiles = 0;
-
-          for (const source of spriteSources) {
-            let spriteBase = source.url;
-            if (isMapboxProtocol(spriteBase) && formData.accessToken) {
-              spriteBase = resolveMapboxUrl(spriteBase, formData.accessToken);
-            }
-
-            // Build sprite URLs; insert suffixes before query string if present
-            const qIndex = spriteBase.indexOf('?');
-            const spriteUrls = suffixes.map(suffix =>
-              qIndex !== -1
-                ? spriteBase.slice(0, qIndex) + suffix + spriteBase.slice(qIndex)
-                : spriteBase + suffix
-            );
-
-            downloadLogger.debug(
-              `Sprite source "${source.id}": ${spriteUrls.length} URLs to download`
-            );
-
-            totalSpriteFiles += spriteUrls.length;
-
-            await spriteService.downloadSprites(spriteUrls, finalStyleId, {
-              onProgress: (progress: { completed: number; total: number }) => {
-                const current = completedSpriteFiles + progress.completed;
-                downloadLogger.debug(`Sprite download: ${current}/${totalSpriteFiles}`);
-                this.updateProgress(
-                  regionId,
-                  regionConfig.name,
-                  'sprites',
-                  current,
-                  totalSpriteFiles,
-                  'Downloading sprites'
-                );
-              },
-              enableValidation: true,
-              skipExisting: false,
-              // For array sprites, use the source ID as name prefix so each
-              // source's files get distinct storage keys
-              namePrefix: source.id !== 'sprite' ? source.id : undefined,
-            });
-
-            completedSpriteFiles += spriteUrls.length;
-          }
-          downloadLogger.debug('Sprites downloaded successfully');
-        } catch (spriteError) {
-          downloadLogger.error('Failed to download sprites (non-fatal):', spriteError);
-        }
-      } else if (rawSprite) {
-        downloadLogger.debug(
-          'Skipping sprite download - sprite URL is already patched or unrecognized:',
-          rawSprite
-        );
-      }
-
-      // Download glyphs if the style has them
-      if (
-        originalStyleForResources?.glyphs &&
-        !originalStyleForResources.glyphs.startsWith('idb://')
-      ) {
-        downloadLogger.debug('Downloading glyphs for style:', finalStyleId);
-        downloadLogger.debug('Original glyphs URL:', originalStyleForResources.glyphs);
-        try {
-          const { GlyphService } = await import('@/services/glyphService');
-          const glyphService = new GlyphService();
-
-          // Extract font families from layers (expression-aware)
-          const fontFamilyArray = extractAllFontNames(
-            styleData.style as { layers?: Array<{ layout?: { [key: string]: unknown } }> }
+      await this.offlineManager.downloadRegion(regionConfig, {
+        provider: formData.provider || 'auto',
+        accessToken: formData.accessToken,
+        onProgress: progress => {
+          const uiPhase: DownloadProgress['phase'] | undefined =
+            progress.phase === 'metadata' ? undefined : progress.phase;
+          this.updateProgress(
+            regionId,
+            regionConfig.name,
+            uiPhase,
+            progress.completed,
+            progress.total,
+            progress.message ?? `Downloading ${progress.phase}`
           );
-          const fontFamilies = new Set<string>(fontFamilyArray);
-
-          if (fontFamilies.size > 0) {
-            downloadLogger.debug('Fonts to download:', Array.from(fontFamilies));
-
-            // Download comprehensive set of glyph ranges for complete font coverage
-            // These ranges cover most common Unicode blocks
-            const glyphRanges = [
-              '0-255', // Basic Latin + Latin-1 Supplement
-              '256-511', // Latin Extended-A + Latin Extended-B
-              '512-767', // IPA Extensions + Spacing Modifier Letters
-              '768-1023', // Combining Diacritical Marks + Greek and Coptic
-              '1024-1279', // Cyrillic + Cyrillic Supplement
-              '1280-1535', // Armenian + Hebrew
-              '1536-1791', // Arabic
-              '1792-2047', // Syriac + Arabic Supplement + Thaana
-              '2048-2303', // NKo + Samaritan + Mandaic
-              '2304-2559', // Devanagari + Bengali
-              '2560-2815', // Gurmukhi + Gujarati
-              '8192-8447', // General Punctuation, Superscripts/Subscripts, Currency Symbols
-              '8448-8703', // Letterlike Symbols, Number Forms, Arrows
-              '2816-3071', // Oriya + Tamil
-              '3072-3327', // Telugu + Kannada
-              '3328-3583', // Malayalam + Sinhala
-              '3584-3839', // Thai + Lao
-              '3840-4095', // Tibetan + Myanmar
-              '4096-4351', // Georgian + Hangul Jamo
-              '4352-4607', // Ethiopic
-              '4608-4863', // Cherokee + Canadian Aboriginal
-              '11904-12031', // CJK Radicals Supplement
-              '12032-12255', // Kangxi Radicals + CJK Symbols
-              '12288-12543', // Hiragana + Katakana
-              '12544-12799', // Bopomofo + Hangul Compatibility Jamo
-              '19968-20223', // CJK Unified Ideographs (first block)
-              '20224-20479', // CJK Unified Ideographs
-              '40960-42127', // Yi Syllables + Yi Radicals
-              '44032-55203', // Hangul Syllables (Korean)
-              '7680-7935', // Latin Extended Additional
-              '63744-64255', // CJK Compatibility Ideographs
-              '64256-64511', // Alphabetic Presentation Forms
-              '65024-65279', // Variation Selectors
-              '65280-65535', // Halfwidth and Fullwidth Forms
-            ];
-
-            let glyphsUrl = originalStyleForResources.glyphs;
-            if (isMapboxProtocol(glyphsUrl) && formData.accessToken) {
-              glyphsUrl = resolveMapboxUrl(glyphsUrl, formData.accessToken);
-            }
-
-            await glyphService.downloadGlyphs(
-              glyphsUrl, // Use ORIGINAL unpatched glyphs URL (resolved if mapbox://)
-              Array.from(fontFamilies),
-              finalStyleId,
-              glyphRanges,
-              {
-                onProgress: (progress: { completed: number; total: number }) => {
-                  downloadLogger.debug(`Glyph download: ${progress.completed}/${progress.total}`);
-                  this.updateProgress(
-                    regionId,
-                    regionConfig.name,
-                    'glyphs',
-                    progress.completed,
-                    progress.total,
-                    'Downloading glyphs'
-                  );
-                },
-              }
-            );
-            downloadLogger.debug('Glyphs downloaded successfully');
-          } else {
-            downloadLogger.debug('No fonts found in style layers');
-          }
-        } catch (glyphError) {
-          downloadLogger.error('Failed to download glyphs (non-fatal):', glyphError);
-        }
-      } else if (originalStyleForResources?.glyphs?.startsWith('idb://')) {
-        downloadLogger.debug(
-          'Skipping glyph download - glyphs URL is already patched:',
-          originalStyleForResources.glyphs
-        );
-      }
-
-      // Then download tiles for the region
-      downloadLogger.debug('Starting tile download for region:', regionId);
-      downloadLogger.debug('Region config:', finalRegionConfig);
-      downloadLogger.debug('Style data sources:', Object.keys(styleData.style?.sources || {}));
-
-      // Use the already-fetched style data
-      if (!styleData) {
-        throw new Error('Style not found for tile download');
-      }
-
-      if (!styleData.style) {
-        throw new Error('Style data does not contain style object');
-      }
-
-      if (!styleData.style.sources || Object.keys(styleData.style.sources).length === 0) {
-        throw new Error(
-          'Style does not contain any sources for tile download. ' +
-            'If this style uses imports (e.g. Mapbox Standard), import resolution may have failed.'
-        );
-      }
-
-      downloadLogger.debug('Calling downloadTiles with finalStyleId:', finalStyleId);
-      downloadLogger.debug(
-        'Stored style sources:',
-        Object.keys(styleWithEmbeddedSources?.sources || {})
-      );
-
-      // Log source details to verify we have tile URLs
-      if (styleWithEmbeddedSources?.sources) {
-        for (const [sourceId, source] of Object.entries(styleWithEmbeddedSources.sources)) {
-          const typedSource = source as { tiles?: string[]; url?: string };
-          downloadLogger.debug(`Source ${sourceId}:`, {
-            hasTiles: !!typedSource.tiles,
-            tilesCount: typedSource.tiles?.length,
-            firstTileUrl: typedSource.tiles?.[0],
-            hasUrl: !!typedSource.url,
-          });
-        }
-      }
-
-      // Use stored style with embedded TileJSON (has tiles array) for tile downloads
-      const tileResult = await downloadTiles(
-        finalRegionConfig,
-        styleWithEmbeddedSources,
-        finalStyleId,
-        {
-          onProgress: progress => {
-            downloadLogger.debug(
-              `Tile download progress: ${progress.completed}/${progress.total} (${progress.percentage.toFixed(1)}%)`
-            );
-            this.updateProgress(
-              regionId,
-              regionConfig.name,
-              'tiles',
-              progress.completed,
-              progress.total,
-              progress.message || 'Downloading tiles'
-            );
-          },
-          skipExisting: false, // Always download tiles to ensure fresh data
-          batchSize: 20,
+        },
+        tileOptions: {
           maxConcurrency: 10,
-        }
-      );
-
-      downloadLogger.debug('Tile download completed for region:', regionId);
-      downloadLogger.debug('Tile download result:', {
-        totalTiles: tileResult.totalTiles,
-        downloadedTiles: tileResult.downloadedTiles,
-        failedTiles: tileResult.failedTiles,
-        skippedTiles: tileResult.skippedTiles,
-        totalSize: tileResult.totalSize,
-        tileExtension: tileResult.tileExtension, // Extension used for tiles (mvt, pbf, etc.)
-        hasErrors: tileResult.errors?.length > 0,
+        },
       });
 
-      if (tileResult.failedTiles > 0 || (tileResult.errors && tileResult.errors.length > 0)) {
-        downloadLogger.error('Tile download had errors:', tileResult.errors);
-      }
-
-      if (tileResult.downloadedTiles === 0 && tileResult.skippedTiles === 0) {
-        downloadLogger.warn(
-          'WARNING: No tiles were downloaded! Check the style sources and TileJSON.'
-        );
-      }
-
-      // NOW add the region metadata - this patches the style URLs to idb:// for offline use
-      // This MUST happen AFTER all downloads are complete since patching converts URLs to idb://
-      // NOTE: Do NOT pass tileExtension here. patchStyleForOffline extracts the correct extension
-      // per-source from the tile URL patterns. Passing a single extension from the first source
-      // would incorrectly override all sources (e.g., applying .png from a raster source to vector sources).
-      downloadLogger.debug('Adding region metadata and patching style for offline use');
-      await this.offlineManager.addRegion(finalRegionConfig);
-
-      // Download complete
       this.handleDownloadComplete(regionId);
     } catch (error) {
       downloadLogger.error('Error downloading region:', error);
@@ -609,28 +272,6 @@ export class DownloadManager {
   private updateUIForDownloadStart(): void {
     this.options.updateButton?.('Downloading...', true);
     this.options.updateProgressBadge?.('0%', true);
-  }
-
-  /**
-   * Normalize the style's sprite property into a uniform array of {id, url} sources.
-   * Handles string format, array format, and filters out already-patched idb:// URLs.
-   */
-  private normalizeSpriteProperty(sprite: unknown): Array<{ id: string; url: string }> {
-    if (!sprite) return [];
-
-    // Array format: [{id: "default", url: "https://..."}, ...]
-    if (Array.isArray(sprite)) {
-      return (sprite as Array<{ id: string; url: string }>).filter(
-        entry => entry && typeof entry.url === 'string' && !entry.url.startsWith('idb://')
-      );
-    }
-
-    // String format: "https://example.com/sprites/sprite"
-    if (typeof sprite === 'string' && !sprite.startsWith('idb://')) {
-      return [{ id: 'sprite', url: sprite }];
-    }
-
-    return [];
   }
 
   /**

--- a/src/ui/offlineManagerControl.ts
+++ b/src/ui/offlineManagerControl.ts
@@ -782,43 +782,6 @@ export class OfflineManagerControl implements IControl {
   }
 
   /**
-   * Load styles from IndexedDB and apply to map
-   */
-  private async loadStylesFromIDB(): Promise<void> {
-    if (!this.map) {
-      controlLogger.warn('Map not available for loading IDB styles');
-      return;
-    }
-
-    try {
-      // Import the loadStyles function from styleService
-      const { loadStyles } = await import('@/services/styleService');
-
-      // Get stored styles from IndexedDB
-      const styles = await loadStyles();
-
-      if (styles.length === 0) {
-        controlLogger.warn('No styles found in IndexedDB');
-        alert('No offline styles available. Please download a style first.');
-        return;
-      }
-
-      // If only one style, load it directly
-      if (styles.length === 1) {
-        const styleToLoad = styles[0];
-        await this.loadOfflineStyle(styleToLoad.key);
-        this.renderPanel();
-        return;
-      }
-
-      // Multiple styles - show selection dialog
-      this.showStyleSelectionModal(styles);
-    } catch (error) {
-      controlLogger.error('Error loading styles from IDB:', error);
-    }
-  }
-
-  /**
    * Show modal to select which style to load
    */
   private showStyleSelectionModal(
@@ -907,17 +870,31 @@ export class OfflineManagerControl implements IControl {
    * ```
    */
   async loadOfflineStyles(): Promise<void> {
-    await this.loadStylesFromIDB();
-  }
+    if (!this.map) {
+      controlLogger.warn('Map not available for loading IDB styles');
+      return;
+    }
 
-  /**
-   * Load a specific offline style by its ID.
-   * Alias for `loadOfflineStyle()` for API clarity.
-   *
-   * @param styleId - The unique identifier of the stored style
-   */
-  async loadSpecificOfflineStyle(styleId: string): Promise<void> {
-    await this.loadOfflineStyle(styleId);
+    try {
+      const { loadStyles } = await import('@/services/styleService');
+      const styles = await loadStyles();
+
+      if (styles.length === 0) {
+        controlLogger.warn('No styles found in IndexedDB');
+        alert('No offline styles available. Please download a style first.');
+        return;
+      }
+
+      if (styles.length === 1) {
+        await this.loadOfflineStyle(styles[0].key);
+        this.renderPanel();
+        return;
+      }
+
+      this.showStyleSelectionModal(styles);
+    } catch (error) {
+      controlLogger.error('Error loading styles from IDB:', error);
+    }
   }
 
   /**

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -57,6 +57,9 @@ export const GLYPH_CONFIG = {
     '4096-4351', // Georgian + Hangul Jamo
     '4352-4607', // Ethiopic
     '4608-4863', // Cherokee + Canadian Aboriginal
+    '7680-7935', // Latin Extended Additional
+    '8192-8447', // General Punctuation, Superscripts/Subscripts, Currency Symbols
+    '8448-8703', // Letterlike Symbols, Number Forms, Arrows
     '11904-12031', // CJK Radicals Supplement
     '12032-12255', // Kangxi Radicals + CJK Symbols
     '12288-12543', // Hiragana + Katakana
@@ -66,6 +69,8 @@ export const GLYPH_CONFIG = {
     '40960-42127', // Yi Syllables + Yi Radicals
     '44032-55203', // Hangul Syllables (Korean)
     '63744-64255', // CJK Compatibility Ideographs
+    '64256-64511', // Alphabetic Presentation Forms
+    '65024-65279', // Variation Selectors
     '65280-65535', // Halfwidth and Fullwidth Forms
   ] as const,
 } as const;

--- a/src/utils/styleUtils.ts
+++ b/src/utils/styleUtils.ts
@@ -209,6 +209,23 @@ export function extractFontNamesFromTextField(textFont: unknown): string[] {
 }
 
 /**
+ * Normalize a style's `sprite` property into a uniform array of {id, url} sources.
+ * Handles string format, array format, and filters out already-patched idb:// URLs.
+ */
+export function normalizeSpriteProperty(sprite: unknown): Array<{ id: string; url: string }> {
+  if (!sprite) return [];
+  if (Array.isArray(sprite)) {
+    return (sprite as Array<{ id: string; url: string }>).filter(
+      entry => entry && typeof entry.url === 'string' && !entry.url.startsWith('idb://')
+    );
+  }
+  if (typeof sprite === 'string' && !sprite.startsWith('idb://')) {
+    return [{ id: 'sprite', url: sprite }];
+  }
+  return [];
+}
+
+/**
  * Collect all unique font names referenced in a style's layers.
  */
 export function extractAllFontNames(style: {

--- a/tests/integration/serviceIntegration.test.ts
+++ b/tests/integration/serviceIntegration.test.ts
@@ -43,7 +43,7 @@ describe('Service Integration', () => {
 
       // Both services should see the same data
       const tileStats = await tileService.getTileStats();
-      const resourceStats = await resourceService.getTileStatistics();
+      const resourceStats = await resourceService.getTileStats();
 
       expect(tileStats.count).toBe(1);
       expect(resourceStats.count).toBe(1);
@@ -73,7 +73,7 @@ describe('Service Integration', () => {
 
       // Both services should report tile
       let tileStats = await tileService.getTileStats();
-      let resourceStats = await resourceService.getTileStatistics();
+      let resourceStats = await resourceService.getTileStats();
       expect(tileStats.count).toBe(1);
       expect(resourceStats.count).toBe(1);
 
@@ -82,7 +82,7 @@ describe('Service Integration', () => {
 
       // Both services should report no tiles
       tileStats = await tileService.getTileStats();
-      resourceStats = await resourceService.getTileStatistics();
+      resourceStats = await resourceService.getTileStats();
       expect(tileStats.count).toBe(0);
       expect(resourceStats.count).toBe(0);
     });
@@ -108,7 +108,7 @@ describe('Service Integration', () => {
       });
 
       const spriteStats = await spriteService.getSpriteStats();
-      const resourceStats = await resourceService.getSpriteStatistics();
+      const resourceStats = await resourceService.getSpriteStats();
 
       expect(spriteStats.count).toBe(1);
       expect(resourceStats.count).toBe(1);
@@ -177,10 +177,10 @@ describe('Service Integration', () => {
       });
 
       // Verify all resource types
-      const tileStats = await resourceService.getTileStatistics();
-      const spriteStats = await resourceService.getSpriteStatistics();
-      const fontStats = await resourceService.getFontStatistics();
-      const glyphStats = await resourceService.getGlyphStatistics();
+      const tileStats = await resourceService.getTileStats();
+      const spriteStats = await resourceService.getSpriteStats();
+      const fontStats = await resourceService.getFontStats();
+      const glyphStats = await resourceService.getGlyphStats();
 
       expect(tileStats.count).toBe(1);
       expect(spriteStats.count).toBe(1);
@@ -253,8 +253,8 @@ describe('Service Integration', () => {
       });
 
       // Filter by style
-      const filteredStats = await resourceService.getTileStatistics(styleId);
-      const allStats = await resourceService.getTileStatistics();
+      const filteredStats = await resourceService.getTileStats(styleId);
+      const allStats = await resourceService.getTileStats();
 
       expect(filteredStats.count).toBe(2);
       expect(filteredStats.totalSize).toBe(2500);
@@ -303,8 +303,8 @@ describe('Service Integration', () => {
       const [tileStats, spriteStats, resourceTileStats, resourceSpriteStats] = await Promise.all([
         tileService.getTileStats(),
         spriteService.getSpriteStats(),
-        resourceService.getTileStatistics(),
-        resourceService.getSpriteStatistics(),
+        resourceService.getTileStats(),
+        resourceService.getSpriteStats(),
       ]);
 
       expect(tileStats.count).toBe(1);

--- a/tests/services/regionService.test.ts
+++ b/tests/services/regionService.test.ts
@@ -519,6 +519,31 @@ describe('RegionService', () => {
       expect(phases).toEqual(expect.arrayContaining(['style', 'sprites', 'glyphs', 'tiles', 'metadata']));
     });
 
+    it('does not auto-fill tileExtension from tileResult (regression: mixed-format styles)', async () => {
+      // tileResult.tileExtension is the first source's extension only; passing
+      // it through to addRegion→patchStyleForOffline would override ALL
+      // sources (e.g., .png from a raster source would clobber vector .pbf).
+      await seedStyle();
+      mockDownloadTiles.mockResolvedValueOnce({
+        totalTiles: 0,
+        downloadedTiles: 0,
+        skippedTiles: 0,
+        failedTiles: 0,
+        totalSize: 0,
+        downloadTime: 0,
+        averageSpeed: 0,
+        errors: [],
+        tileExtension: 'png', // raster, e.g.
+      });
+
+      await regionService.downloadRegion(makeRegion()); // region has no tileExtension
+
+      const db = await dbPromise;
+      const style = await db.get('styles', 'test-style-id');
+      const stored = style?.regions[0] as { tileExtension?: string } | undefined;
+      expect(stored?.tileExtension).toBeUndefined();
+    });
+
     it('downloads the style when missing and then continues the pipeline', async () => {
       mockDownloadStyleWithProvider.mockImplementation(async (styleUrl: string) => {
         // Emulate downloadStyleWithProvider by writing the style to the DB

--- a/tests/services/regionService.test.ts
+++ b/tests/services/regionService.test.ts
@@ -1,15 +1,72 @@
 /**
  * Tests for Region Service
  */
+const mockDownloadTiles = jest.fn();
+const mockDownloadSprites = jest.fn();
+const mockDownloadGlyphs = jest.fn();
+const mockDownloadStyleWithProvider = jest.fn();
+
+jest.mock('../../src/services/tileService', () => {
+  const actual = jest.requireActual('../../src/services/tileService');
+  return {
+    ...actual,
+    downloadTiles: (...args: unknown[]) => mockDownloadTiles(...args),
+  };
+});
+
+jest.mock('../../src/services/spriteService', () => {
+  const actual = jest.requireActual('../../src/services/spriteService');
+  return {
+    ...actual,
+    downloadSprites: (...args: unknown[]) => mockDownloadSprites(...args),
+  };
+});
+
+jest.mock('../../src/services/glyphService', () => {
+  const actual = jest.requireActual('../../src/services/glyphService');
+  return {
+    ...actual,
+    downloadGlyphs: (...args: unknown[]) => mockDownloadGlyphs(...args),
+  };
+});
+
+jest.mock('../../src/services/styleService', () => {
+  const actual = jest.requireActual('../../src/services/styleService');
+  return {
+    ...actual,
+    downloadStyleWithProvider: (...args: unknown[]) => mockDownloadStyleWithProvider(...args),
+  };
+});
+
 import { RegionService } from '../../src/services/regionService';
 import { dbPromise } from '../../src/storage/indexedDbManager';
 import type { StyleProvider } from '../../src/types/style';
+import { GLYPH_CONFIG } from '../../src/utils/constants';
 
 describe('RegionService', () => {
   let regionService: RegionService;
 
   beforeEach(async () => {
     regionService = new RegionService();
+
+    mockDownloadTiles.mockReset();
+    mockDownloadSprites.mockReset();
+    mockDownloadGlyphs.mockReset();
+    mockDownloadStyleWithProvider.mockReset();
+
+    mockDownloadTiles.mockResolvedValue({
+      totalTiles: 0,
+      downloadedTiles: 0,
+      skippedTiles: 0,
+      failedTiles: 0,
+      totalSize: 0,
+      downloadTime: 0,
+      averageSpeed: 0,
+      errors: [],
+      tileExtension: 'pbf',
+    });
+    mockDownloadSprites.mockResolvedValue({ downloaded: 0, failed: 0 });
+    mockDownloadGlyphs.mockResolvedValue({ downloaded: 0, failed: 0 });
 
     // Clear all relevant stores before each test
     const db = await dbPromise;
@@ -384,6 +441,132 @@ describe('RegionService', () => {
       expect(style).toBeDefined();
       expect(style?.regions.length).toBe(1);
       expect(style?.regions[0].id).toBe('region-2');
+    });
+  });
+
+  describe('downloadRegion', () => {
+    const seedStyle = async (overrides: Partial<Record<string, unknown>> = {}) => {
+      const db = await dbPromise;
+      await db.put('styles', {
+        key: 'test-style-id',
+        style: {
+          version: 8,
+          sources: { v: { tiles: ['http://tiles/{z}/{x}/{y}.pbf'] } },
+          layers: [
+            { id: 'text', type: 'symbol', layout: { 'text-font': ['Open Sans Regular'] } },
+          ],
+          sprite: 'https://example.com/sprites/sprite',
+          glyphs: 'https://example.com/fonts/{fontstack}/{range}.pbf',
+        },
+        originalUrl: 'https://example.com/style.json',
+        originalSpriteUrl: 'https://example.com/sprites/sprite',
+        originalGlyphsUrl: 'https://example.com/fonts/{fontstack}/{range}.pbf',
+        provider: 'auto' as StyleProvider,
+        regions: [],
+        fonts: [],
+        glyphs: [],
+        sprites: [],
+        ...overrides,
+      });
+    };
+
+    const makeRegion = () => ({
+      id: 'region-prog',
+      name: 'Programmatic Region',
+      bounds: [[-122.5, 37.7], [-122.3, 37.9]] as [[number, number], [number, number]],
+      minZoom: 10,
+      maxZoom: 12,
+      styleUrl: 'https://example.com/style.json',
+    });
+
+    it('throws when no styleUrl is provided', async () => {
+      await expect(
+        regionService.downloadRegion({
+          id: 'x',
+          name: 'x',
+          bounds: [[0, 0], [1, 1]],
+          minZoom: 0,
+          maxZoom: 0,
+        } as never)
+      ).rejects.toThrow('Region must have a styleUrl');
+    });
+
+    it('runs sprites → glyphs → tiles → metadata and stores the region', async () => {
+      await seedStyle();
+      const phases: string[] = [];
+
+      const result = await regionService.downloadRegion(makeRegion(), {
+        onProgress: p => {
+          if (!phases.includes(p.phase)) phases.push(p.phase);
+        },
+      });
+
+      expect(mockDownloadSprites).toHaveBeenCalledTimes(1);
+      expect(mockDownloadGlyphs).toHaveBeenCalledTimes(1);
+      expect(mockDownloadTiles).toHaveBeenCalledTimes(1);
+
+      // Glyph ranges must come from the comprehensive-ranges constant
+      const glyphRanges = mockDownloadGlyphs.mock.calls[0][3];
+      expect(glyphRanges).toEqual([...GLYPH_CONFIG.COMPREHENSIVE_RANGES]);
+
+      // Metadata persisted last, inside styles.regions[]
+      const db = await dbPromise;
+      const style = await db.get('styles', 'test-style-id');
+      expect(style?.regions).toHaveLength(1);
+      expect(style?.regions[0]).toMatchObject({ id: 'region-prog', styleId: 'test-style-id' });
+
+      expect(result.styleId).toBe('test-style-id');
+      expect(phases).toEqual(expect.arrayContaining(['style', 'sprites', 'glyphs', 'tiles', 'metadata']));
+    });
+
+    it('downloads the style when missing and then continues the pipeline', async () => {
+      mockDownloadStyleWithProvider.mockImplementation(async (styleUrl: string) => {
+        // Emulate downloadStyleWithProvider by writing the style to the DB
+        const db = await dbPromise;
+        await db.put('styles', {
+          key: 'fresh-style-id',
+          style: { version: 8, sources: { v: { tiles: ['http://t/{z}/{x}/{y}.pbf'] } }, layers: [] },
+          originalUrl: styleUrl,
+          provider: 'auto' as StyleProvider,
+          regions: [],
+          fonts: [],
+          glyphs: [],
+          sprites: [],
+        });
+        return {
+          styleId: 'fresh-style-id',
+          success: true,
+          downloadTime: 0,
+          styleSize: 0,
+          sourcesProcessed: 0,
+          sourcesEmbedded: 0,
+          errors: [],
+          analytics: { sourceTypes: {}, layerTypes: {}, totalLayers: 0, hasGlyphs: false, hasSprites: false },
+        };
+      });
+
+      const result = await regionService.downloadRegion(makeRegion());
+
+      expect(mockDownloadStyleWithProvider).toHaveBeenCalledWith(
+        'https://example.com/style.json',
+        expect.objectContaining({ enableSourceEmbedding: true, skipExisting: true })
+      );
+      expect(mockDownloadTiles).toHaveBeenCalledTimes(1);
+      expect(result.styleId).toBe('fresh-style-id');
+    });
+
+    it('skips sprites and glyphs when asked', async () => {
+      await seedStyle();
+      await regionService.downloadRegion(makeRegion(), { skipSprites: true, skipGlyphs: true });
+      expect(mockDownloadSprites).not.toHaveBeenCalled();
+      expect(mockDownloadGlyphs).not.toHaveBeenCalled();
+      expect(mockDownloadTiles).toHaveBeenCalledTimes(1);
+    });
+
+    it('loadRegion is an alias for downloadRegion', async () => {
+      await seedStyle();
+      await regionService.loadRegion(makeRegion());
+      expect(mockDownloadTiles).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/tests/services/resourceService.test.ts
+++ b/tests/services/resourceService.test.ts
@@ -17,9 +17,9 @@ describe('ResourceService', () => {
   });
 
   describe('Tile Management', () => {
-    describe('getTileStatistics', () => {
+    describe('getTileStats', () => {
       it('should return empty stats when no tiles exist', async () => {
-        const stats = await service.getTileStatistics();
+        const stats = await service.getTileStats();
 
         expect(stats.count).toBe(0);
         expect(stats.totalSize).toBe(0);
@@ -43,7 +43,7 @@ describe('ResourceService', () => {
           lastModified: Date.now(),
         });
 
-        const stats = await service.getTileStatistics();
+        const stats = await service.getTileStats();
 
         expect(stats.count).toBe(1);
         expect(stats.totalSize).toBe(1000);
@@ -82,7 +82,7 @@ describe('ResourceService', () => {
           lastModified: Date.now(),
         });
 
-        const stats = await service.getTileStatistics('style-1');
+        const stats = await service.getTileStats('style-1');
 
         expect(stats.count).toBe(1);
         expect(stats.totalSize).toBe(1000);
@@ -127,9 +127,9 @@ describe('ResourceService', () => {
   });
 
   describe('Font Management', () => {
-    describe('getFontStatistics', () => {
+    describe('getFontStats', () => {
       it('should return font statistics', async () => {
-        const stats = await service.getFontStatistics();
+        const stats = await service.getFontStats();
 
         expect(stats).toHaveProperty('count');
         expect(stats).toHaveProperty('totalSize');
@@ -179,9 +179,9 @@ describe('ResourceService', () => {
   });
 
   describe('Sprite Management', () => {
-    describe('getSpriteStatistics', () => {
+    describe('getSpriteStats', () => {
       it('should return sprite statistics', async () => {
-        const stats = await service.getSpriteStatistics();
+        const stats = await service.getSpriteStats();
 
         expect(stats).toHaveProperty('count');
         expect(stats).toHaveProperty('totalSize');
@@ -228,9 +228,9 @@ describe('ResourceService', () => {
   });
 
   describe('Glyph Management', () => {
-    describe('getGlyphStatistics', () => {
+    describe('getGlyphStats', () => {
       it('should return glyph statistics', async () => {
-        const stats = await service.getGlyphStatistics();
+        const stats = await service.getGlyphStats();
 
         expect(stats).toHaveProperty('count');
         expect(stats).toHaveProperty('totalSize');

--- a/tests/ui/managers/downloadManager.test.ts
+++ b/tests/ui/managers/downloadManager.test.ts
@@ -359,20 +359,25 @@ describe('DownloadManager', () => {
     });
   });
 
-  describe('addRegion without tileExtension', () => {
-    it('should call addRegion without tileExtension property', async () => {
+  describe('delegates to offlineManager.downloadRegion', () => {
+    it('should pass the constructed region config and UI progress hooks through', async () => {
       const mockOfflineManager = createMockOfflineManager();
-
-      const { isStyleDownloaded, loadStyles } = require('../../../src/services/styleService');
-      isStyleDownloaded.mockResolvedValue(false);
-      loadStyles.mockResolvedValue([{
-        key: 'test-style-id',
-        style: {
-          sources: { testSource: { tiles: ['http://test/{z}/{x}/{y}.pbf'] } },
-          layers: [],
+      const downloadRegion = jest.fn().mockResolvedValue({
+        regionId: 'region_1',
+        styleId: 'test-style-id',
+        spriteResults: [],
+        tileResult: {
+          totalTiles: 0,
+          downloadedTiles: 0,
+          skippedTiles: 0,
+          failedTiles: 0,
+          totalSize: 0,
+          downloadTime: 0,
+          averageSpeed: 0,
+          errors: [],
         },
-        originalUrl: 'https://example.com/style.json',
-      }]);
+      });
+      (mockOfflineManager as unknown as Record<string, unknown>).downloadRegion = downloadRegion;
 
       const options = createOptions({
         offlineManager: mockOfflineManager as unknown as DownloadManagerOptions['offlineManager'],
@@ -385,74 +390,22 @@ describe('DownloadManager', () => {
         minZoom: 10,
         maxZoom: 14,
         styleUrl: 'https://example.com/style.json',
+        provider: 'mapbox' as const,
+        accessToken: 'pk.test',
       });
 
-      expect(mockOfflineManager.addRegion).toHaveBeenCalledTimes(1);
-      const addRegionArg = mockOfflineManager.addRegion.mock.calls[0][0];
-      expect(addRegionArg).not.toHaveProperty('tileExtension');
-      // Should have the expected region fields
-      expect(addRegionArg).toHaveProperty('styleId', 'test-style-id');
-      expect(addRegionArg).toHaveProperty('name', 'Test Region');
-    });
-  });
-
-  describe('glyph download ranges', () => {
-    beforeEach(() => {
-      mockDownloadGlyphs.mockClear();
-    });
-
-    it('should include new Unicode ranges when downloading glyphs', async () => {
-      const mockOfflineManager = createMockOfflineManager();
-
-      const { isStyleDownloaded, loadStyles } = require('../../../src/services/styleService');
-      isStyleDownloaded.mockResolvedValue(false);
-      loadStyles.mockResolvedValue([{
-        key: 'test-style-id',
-        style: {
-          sources: { testSource: { tiles: ['http://test/{z}/{x}/{y}.pbf'] } },
-          layers: [
-            {
-              id: 'text-layer',
-              type: 'symbol',
-              layout: {
-                'text-font': ['Open Sans Regular'],
-                'text-field': '{name}',
-              },
-            },
-          ],
-          glyphs: 'https://example.com/fonts/{fontstack}/{range}.pbf',
-        },
-        originalUrl: 'https://example.com/style.json',
-        originalGlyphsUrl: 'https://example.com/fonts/{fontstack}/{range}.pbf',
-      }]);
-
-      const options = createOptions({
-        offlineManager: mockOfflineManager as unknown as DownloadManagerOptions['offlineManager'],
-      });
-      const manager = new DownloadManager(options);
-
-      await manager.downloadRegion({
+      expect(downloadRegion).toHaveBeenCalledTimes(1);
+      const [regionArg, optionsArg] = downloadRegion.mock.calls[0];
+      expect(regionArg).toMatchObject({
         name: 'Test Region',
-        bounds: [-122.5, 37.7, -122.3, 37.9],
+        styleUrl: 'https://example.com/style.json',
         minZoom: 10,
         maxZoom: 14,
-        styleUrl: 'https://example.com/style.json',
       });
-
-      expect(mockDownloadGlyphs).toHaveBeenCalledTimes(1);
-
-      // The 4th argument is the glyph ranges array
-      const glyphRanges: string[] = mockDownloadGlyphs.mock.calls[0][3];
-
-      // Verify the three new Unicode ranges are included
-      expect(glyphRanges).toContain('7680-7935');   // Latin Extended Additional
-      expect(glyphRanges).toContain('64256-64511');  // Alphabetic Presentation Forms
-      expect(glyphRanges).toContain('65024-65279');  // Variation Selectors
-
-      // Also verify some of the existing ranges are still present
-      expect(glyphRanges).toContain('0-255');        // Basic Latin
-      expect(glyphRanges).toContain('1536-1791');    // Arabic
-      expect(glyphRanges).toContain('65280-65535');   // Halfwidth and Fullwidth Forms
+      expect(regionArg.bounds).toEqual([[-122.5, 37.7], [-122.3, 37.9]]);
+      expect(optionsArg.provider).toBe('mapbox');
+      expect(optionsArg.accessToken).toBe('pk.test');
+      expect(typeof optionsArg.onProgress).toBe('function');
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #18. `offlineManager.addRegion` previously only stored region metadata; tile/sprite/glyph downloads lived entirely inside the UI control's `DownloadManager`, so any programmatic caller ended up with a registered region that had zero offline assets.

This PR adds a true programmatic pipeline and de-duplicates the UI code that duplicated it.

- **New API** — `OfflineMapManager.downloadRegion(region, options?)` runs the full pipeline (style → sprites → glyphs → tiles → metadata) and returns a `DownloadRegionResult`. `loadRegion` is now an alias that forwards to it, replacing the previous stub that only logged `loadTiles function not yet implemented`.
- **Per-phase progress** — callers pass `onProgress(progress)` where `progress` is `{ phase, completed, total, percentage, message? }`; `phase` is one of `style | sprites | glyphs | tiles | metadata`.
- **UI delegation** — `DownloadManager.downloadRegion` now delegates to the service method instead of duplicating ~370 lines of orchestration. It maps phase events onto the existing UI `DownloadProgress` shape so callbacks (`onProgressUpdate`, `updateButton`, `updateProgressBadge`) keep behaving the same.
- **Shared helpers** — `normalizeSpriteProperty` moved to `src/utils/styleUtils.ts`; glyph-range list merged into `GLYPH_CONFIG.COMPREHENSIVE_RANGES` (which gained the five ranges the UI had privately defined: `7680-7935`, `8192-8447`, `8448-8703`, `64256-64511`, `65024-65279`).
- **Class boilerplate removed** — `OfflineMapManager` now uses class/interface declaration merging (`interface OfflineMapManager extends OfflineMapManagerModules {}`) instead of ~50 `declare public X: ModuleName['X']` fields; adding a new module method no longer requires editing `index.ts`.

## Example

```ts
import { OfflineMapManager } from 'map-gl-offline';

const offlineManager = new OfflineMapManager();

await offlineManager.downloadRegion(
  {
    id: 'sf',
    name: 'San Francisco',
    bounds: [[-122.5, 37.7], [-122.3, 37.9]],
    minZoom: 10,
    maxZoom: 14,
    styleUrl: 'https://api.maptiler.com/maps/streets/style.json?key=YOUR_KEY',
  },
  {
    onProgress: ({ phase, completed, total, percentage }) => {
      console.log(`[${phase}] ${completed}/${total} (${percentage.toFixed(1)}%)`);
    },
  },
);
```

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — no new warnings/errors
- [x] `npm test` — 1376/1376 unit tests pass (one pre-existing e2e failure that needs a running dev server is unrelated)
- [x] New `downloadRegion` suites in `tests/services/regionService.test.ts`:
  - throws when `styleUrl` is missing
  - runs sprites → glyphs → tiles → metadata and stores the region inside `styles.regions[]`
  - auto-downloads the style when missing, then continues the pipeline
  - respects `skipSprites` / `skipGlyphs`
  - `loadRegion` alias forwards to `downloadRegion`
- [x] `tests/ui/managers/downloadManager.test.ts` — asserts the UI's `downloadRegion` delegates to `offlineManager.downloadRegion` with the correct region config, provider, accessToken, and progress hook