### PR TITLE
docs: refresh for #19 + #20; tighten README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,93 +4,35 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![TypeScript](https://img.shields.io/badge/TypeScript-100%25-blue.svg)](https://www.typescriptlang.org/)
 
-**[Documentation](https://map-gl-offline.netlify.app)** | **[Live Demo](https://map-gl-offline-demo.netlify.app)**
+**[📖 Documentation](https://map-gl-offline.netlify.app)** · **[🎮 Live Demo](https://map-gl-offline-demo.netlify.app)** · **[🐛 Issues](https://github.com/muimsd/map-gl-offline/issues)**
 
-A comprehensive **TypeScript** library for **MapLibre GL JS** and **Mapbox GL JS** that enables complete offline map functionality with vector/raster tiles, styles, fonts, sprites, and glyphs stored in IndexedDB. Features include Mapbox Standard style support, advanced analytics, intelligent cleanup, i18n (English & Arabic with RTL), and a modern glassmorphic UI control.
-
-## 🎬 Demo
+TypeScript offline-map library for **MapLibre GL JS** and **Mapbox GL JS**. Download styles, tiles, sprites, glyphs, and fonts to IndexedDB; load them back with zero network. Ships with a glassmorphic UI control and a complete programmatic API.
 
 ![Map GL Offline Demo](assets/map-gl-offline-demo.gif)
 
-*Download regions, load offline styles, and navigate maps without an internet connection.*
+## Features
 
-## ✨ Features
+- 🗺️ **Offline regions** — polygon selection, smart tile management, extra vector/raster overlays
+- 🎨 **Full resource capture** — styles, sprites, fonts, glyphs with Unicode ranges
+- 🔗 **Mapbox GL + MapLibre GL** — auto-detection, `mapbox://` URL resolution, Standard style with 3D/terrain
+- 📊 **Analytics & cleanup** — storage reports, auto-cleanup, quota-aware downloads
+- 🎨 **UI control** — glassmorphic panel, dark/light themes, English/Arabic (RTL), polygon drawing
+- 🛠️ **Programmatic API** — `downloadRegion` with per-phase progress, full TypeScript types
 
-### 🎯 Core Offline Capabilities
-
-- 🗺️ **Complete Offline Maps**: Download and store entire map regions with polygon-based selection
-- 🎯 **Smart Tile Management**: Efficient vector/raster tile downloading, caching, and retrieval with zoom-level optimization
-- 🧩 **Extra Tile Sources**: Save additional vector (MVT/PBF) and raster tile layers alongside the style's own sources
-- 🔤 **Font & Glyph Support**: Comprehensive font and glyph management with Unicode range support
-- 🎨 **Sprite Management**: Handle map sprites and icons offline with multi-resolution support (@1x, @2x)
-- 📊 **Real-time Analytics**: Detailed storage analytics, performance metrics, and optimization recommendations
-
-### 🌐 Mapbox GL JS Support
-
-- 🔗 **mapbox:// Protocol Resolution**: Automatic resolution of `mapbox://` style, source, sprite, and glyph URLs
-- 🏙️ **Mapbox Standard Style**: Full support including 3D models, raster-dem terrain, and import-based style resolution
-- 🌅 **Day/Night Light Presets**: Toggle between day and night lighting in Mapbox Standard style
-- 🌧️ **Weather Controls**: Rain and snow effects for Mapbox Standard style
-- 🔍 **Auto-detection**: Automatically detects whether a style is Mapbox or MapLibre and applies the correct handling
-
-### 🎨 Modern UI Control
-
-- 🖼️ **Glassmorphic Design**: Beautiful modern interface with glassmorphism effects and smooth animations
-- 🌓 **Dark/Light Theme**: Automatic theme switching with system preference detection
-- 📍 **Polygon Drawing**: Interactive polygon tool for precise region selection
-- 📊 **Live Progress**: Real-time download progress with detailed statistics
-- 🎯 **Region Management**: Easy-to-use interface for managing multiple offline regions
-- ⚡ **Responsive**: Mobile-friendly design that adapts to all screen sizes
-- 🌍 **Internationalization**: English and Arabic language support with full RTL layout
-
-### 🛠️ Technical Excellence
-
-- 💾 **IndexedDB Storage**: Efficient browser storage with quota management and transaction safety
-- 🔧 **Full TypeScript**: Complete type definitions, interfaces, and compile-time safety
-- ⚡ **Performance Optimized**: Concurrent downloads, async/await patterns, and memory-efficient operations
-- 🧹 **Intelligent Cleanup**: Smart cleanup of expired data with customizable policies
-- 🔄 **Robust Error Handling**: Comprehensive error recovery, retry mechanisms, and graceful degradation
-- 🔍 **Enhanced Logging**: Detailed debugging with zoom-level specific logging (Z12 tracking)
-
-## 📦 Installation
+## Install
 
 ```bash
 npm install map-gl-offline
-# or
-yarn add map-gl-offline
-# or
-pnpm add map-gl-offline
 ```
 
-### CDN (UMD)
-
-For use via `<script>` tag, the library is available as the `mapgloffline` global (similar to `mapboxgl` and `maplibregl`):
+Or via CDN as the `mapgloffline` global:
 
 ```html
 <script src="https://unpkg.com/map-gl-offline/dist/index.umd.js"></script>
 <link rel="stylesheet" href="https://unpkg.com/map-gl-offline/style.css" />
-<script>
-  const manager = new mapgloffline.OfflineMapManager();
-  const control = new mapgloffline.OfflineManagerControl(manager, {
-    styleUrl: 'https://api.maptiler.com/maps/streets/style.json?key=YOUR_KEY',
-  });
-  map.addControl(control, 'top-right');
-</script>
 ```
 
-## 🔑 Environment Setup
-
-For development or when using Maptiler styles, create a `.env` file:
-
-```env
-VITE_MAPTILER_API_KEY=your_api_key_here
-```
-
-Get a free API key from [Maptiler](https://www.maptiler.com/).
-
-For Mapbox styles, you will also need a Mapbox access token from [Mapbox](https://www.mapbox.com/).
-
-## 🚀 Quick Start
+## Quick Start
 
 ### MapLibre GL JS
 
@@ -100,11 +42,9 @@ import { OfflineMapManager, OfflineManagerControl } from 'map-gl-offline';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import 'map-gl-offline/style.css';
 
-const styleUrl = 'https://api.maptiler.com/maps/streets/style.json?key=YOUR_API_KEY';
-
 const map = new maplibregl.Map({
   container: 'map',
-  style: styleUrl,
+  style: 'https://api.maptiler.com/maps/streets/style.json?key=YOUR_KEY',
   center: [-74.006, 40.7128],
   zoom: 12,
 });
@@ -112,48 +52,33 @@ const map = new maplibregl.Map({
 const offlineManager = new OfflineMapManager();
 
 map.on('load', () => {
-  const control = new OfflineManagerControl(offlineManager, {
-    styleUrl,
-    theme: 'dark',
-    showBbox: true,
-    mapLib: maplibregl, // enables idb:// protocol in web workers
-  });
-  map.addControl(control, 'top-right');
+  map.addControl(
+    new OfflineManagerControl(offlineManager, {
+      styleUrl: map.getStyle().sprite,
+      mapLib: maplibregl, // enables idb:// protocol
+    }),
+    'top-right',
+  );
 });
 ```
 
 ### Mapbox GL JS
 
-Mapbox GL JS v3 does not support `addProtocol`, so offline tile serving uses a **Service Worker** fallback. You need to copy `idb-offline-sw.js` to your project's public directory so it is served at the root (`/idb-offline-sw.js`).
-
-**Option 1: CLI (recommended)**
+Mapbox GL JS v3 lacks `addProtocol`, so the library uses a Service Worker. Run **one** of:
 
 ```bash
-npx map-gl-offline init
+npx map-gl-offline init            # CLI (recommended)
+# or add to vite.config.js:
+# import { offlineSwPlugin } from 'map-gl-offline/vite-plugin';
+# plugins: [offlineSwPlugin()]
+# or manually: cp node_modules/map-gl-offline/dist/idb-offline-sw.js public/
 ```
 
-**Option 2: Vite plugin**
-
-```js
-// vite.config.js
-import { offlineSwPlugin } from 'map-gl-offline/vite-plugin';
-
-export default defineConfig({
-  plugins: [offlineSwPlugin()],
-});
-```
-
-**Option 3: Manual copy**
-
-```bash
-cp node_modules/map-gl-offline/dist/idb-offline-sw.js public/idb-offline-sw.js
-```
+Then:
 
 ```typescript
 import mapboxgl from 'mapbox-gl';
 import { OfflineMapManager, OfflineManagerControl } from 'map-gl-offline';
-import 'mapbox-gl/dist/mapbox-gl.css';
-import 'map-gl-offline/style.css';
 
 mapboxgl.accessToken = 'YOUR_MAPBOX_TOKEN';
 
@@ -165,382 +90,103 @@ const map = new mapboxgl.Map({
 });
 
 const offlineManager = new OfflineMapManager();
-
-map.on('load', () => {
-  const control = new OfflineManagerControl(offlineManager, {
-    styleUrl: 'mapbox://styles/mapbox/standard',
-    theme: 'dark',
-    showBbox: true,
-    accessToken: mapboxgl.accessToken,
-    // No mapLib needed - Mapbox GL JS v3 lacks addProtocol,
-    // so the library auto-registers a Service Worker fallback
-  });
-  map.addControl(control, 'top-right');
-});
+map.on('load', () =>
+  map.addControl(
+    new OfflineManagerControl(offlineManager, {
+      styleUrl: 'mapbox://styles/mapbox/standard',
+      accessToken: mapboxgl.accessToken,
+    }),
+    'top-right',
+  ),
+);
 ```
 
-> **Note:** MapLibre GL JS has built-in `addProtocol` support, so it does not need the Service Worker. Only Mapbox GL JS requires this extra step.
+## Programmatic Usage
 
-The UI control provides:
-
-- 📍 **Polygon drawing** for region selection
-- 📊 **Download progress** tracking
-- 🗂️ **Region management** (view, delete)
-- 🌓 **Theme toggle** (dark/light mode)
-- 📈 **Storage analytics**
-- 🌍 **Language switcher** (English / Arabic with RTL)
-
-### Programmatic Usage
+`downloadRegion` runs the full pipeline (**style → sprites → glyphs → tiles → metadata**) with per-phase progress. `addRegion` alone only stores metadata — use `downloadRegion` to actually fetch assets.
 
 ```typescript
 import { OfflineMapManager } from 'map-gl-offline';
 
-// Initialize the offline manager
 const offlineManager = new OfflineMapManager();
 
-// Download a map region for offline use
-await offlineManager.addRegion({
-  id: 'downtown',
-  name: 'Downtown Area',
-  bounds: [
-    [-74.0559, 40.7128], // Southwest [lng, lat]
-    [-74.0059, 40.7628], // Northeast [lng, lat]
-  ],
-  minZoom: 10,
-  maxZoom: 16,
-  styleUrl: 'https://api.maptiler.com/maps/streets/style.json?key=YOUR_KEY',
-  onProgress: progress => {
-    console.log(`Progress: ${progress.percentage}%`);
-    console.log(`Current: ${progress.message}`);
+await offlineManager.downloadRegion(
+  {
+    id: 'downtown',
+    name: 'Downtown',
+    bounds: [[-74.0559, 40.7128], [-74.0059, 40.7628]],
+    minZoom: 10,
+    maxZoom: 16,
+    styleUrl: 'https://api.maptiler.com/maps/streets/style.json?key=YOUR_KEY',
   },
-});
-
-// Retrieve a stored region
-const region = await offlineManager.getStoredRegion('downtown');
-if (region) {
-  console.log(`Region: ${region.name}, created: ${new Date(region.created).toLocaleDateString()}`);
-}
-
-// List all regions
-const regions = await offlineManager.listStoredRegions();
-console.log(`Stored regions:`, regions);
-
-// Delete a region
-await offlineManager.deleteRegion('downtown');
-```
-
-### Analytics & Monitoring
-
-```typescript
-// Get comprehensive storage analytics
-const analytics = await offlineManager.getComprehensiveStorageAnalytics();
-console.log(`Total storage: ${analytics.totalStorageSize} bytes`);
-console.log(`Tiles: ${analytics.tiles.count} (${analytics.tiles.totalSize} bytes)`);
-console.log(`Fonts: ${analytics.fonts.count} (${analytics.fonts.totalSize} bytes)`);
-console.log(`Sprites: ${analytics.sprites.count} (${analytics.sprites.totalSize} bytes)`);
-console.log(`Recommendations:`, analytics.recommendations);
-```
-
-### Cleanup & Maintenance
-
-```typescript
-// Clean up expired regions
-const deletedCount = await offlineManager.cleanupExpiredRegions();
-console.log(`Cleaned ${deletedCount} expired regions`);
-
-// Verify and repair fonts
-const verification = await offlineManager.verifyAndRepairFonts('style_123', { removeCorrupted: true });
-console.log(`Verified: ${verification.verified}, Repaired: ${verification.repaired}, Removed: ${verification.removed}`);
-
-// Set up automatic cleanup (runs every 24 hours)
-const cleanupId = await offlineManager.setupAutoCleanup({
-  intervalHours: 24,
-  maxAge: 30, // days
-});
-```
-
-## 📚 API Reference
-
-### OfflineMapManager
-
-Main class for managing offline maps.
-
-**Constructor:**
-
-```typescript
-const manager = new OfflineMapManager(overrides?: OfflineManagerServiceOverrides);
-```
-
-The constructor accepts optional service overrides for dependency injection (advanced usage). For most cases, use the default: `new OfflineMapManager()`.
-
-**Core Methods:**
-
-- `addRegion(options: OfflineRegionOptions)` - Download and store a map region
-- `getStoredRegion(id: string)` - Retrieve a stored region by ID
-- `deleteRegion(id: string)` - Delete a specific region and its resources
-- `listStoredRegions()` - List all stored regions with metadata
-- `listRegions()` - List all region options
-
-**Analytics Methods:**
-
-- `getComprehensiveStorageAnalytics()` - Get detailed storage statistics
-- `getRegionAnalytics()` - Get aggregate analytics across all regions
-- `getTileStats(styleId?: string)` - Get tile statistics (optionally filtered by style)
-- `getFontStats()` - Get font statistics
-- `getSpriteStats()` - Get sprite statistics
-- `getGlyphStats()` - Get glyph statistics
-
-**Cleanup & Maintenance Methods:**
-
-- `cleanupExpiredRegions()` - Remove regions past expiration date
-- `performSmartCleanup(options)` - Intelligent cleanup with configurable criteria
-- `cleanupOldFonts(styleId?, options?)` - Remove old font data
-- `cleanupOldSprites(styleId?, options?)` - Remove old sprite data
-- `cleanupOldGlyphs(styleId?, options?)` - Remove old glyph data
-- `verifyAndRepairFonts(styleId, options?)` - Verify font integrity
-- `verifyAndRepairSprites(styleId, options?)` - Verify sprite integrity
-- `verifyAndRepairGlyphs(styleId, options?)` - Verify glyph integrity
-- `setupAutoCleanup(options)` - Enable automatic periodic cleanup
-- `stopAutoCleanup(cleanupId?)` - Disable a specific auto-cleanup
-- `stopAllAutoCleanup()` - Disable all auto-cleanups
-- `performCompleteMaintenance(options?)` - Run comprehensive maintenance
-
-### OfflineManagerControl
-
-UI control for MapLibre GL JS and Mapbox GL JS with glassmorphic design.
-
-**Constructor:**
-
-```typescript
-const offlineManager = new OfflineMapManager();
-
-const control = new OfflineManagerControl(offlineManager, {
-  styleUrl: 'https://example.com/style.json', // Map style URL (required)
-  theme?: 'light' | 'dark',                   // UI theme (default: 'dark')
-  showBbox?: boolean,                          // Show region bounding boxes (default: false)
-  accessToken?: string,                        // Mapbox access token (for mapbox:// URLs)
-  mapLib?: MapLibProtocol,                     // Map library module (e.g. maplibregl) for idb:// protocol
-});
-```
-
-**Features:**
-
-- Interactive polygon drawing for region selection
-- Real-time download progress tracking
-- Region management (view, delete)
-- Theme toggle (dark/light mode)
-- Storage analytics display
-- Language switcher (English / Arabic with RTL support)
-- Responsive mobile-friendly design
-
-## 🔧 Configuration Options
-
-### OfflineRegionOptions
-
-```typescript
-interface OfflineRegionOptions {
-  id: string; // Unique region identifier
-  name: string; // Human-readable name (required)
-  bounds: [[number, number], [number, number]]; // [[lng, lat], [lng, lat]]
-  minZoom: number; // Minimum zoom level (e.g., 10)
-  maxZoom: number; // Maximum zoom level (e.g., 16)
-  styleUrl?: string; // Map style URL
-  expiry?: number; // Expiration timestamp (ms since epoch)
-  deleteOnExpiry?: boolean; // Auto-delete on expiration
-  multipleRegions?: boolean; // Part of a multi-region download
-  tileExtension?: string; // Tile extension (pbf, mvt, png, etc.)
-  extraSources?: ExtraSource[]; // Additional tile sources to download alongside the style
-}
-
-interface ExtraSource {
-  id: string; // Unique source identifier
-  type?: 'vector' | 'raster' | 'raster-dem'; // Defaults to 'vector'
-  tiles: string[]; // Tile URL templates with {z}/{x}/{y}
-  minzoom?: number;
-  maxzoom?: number;
-  attribution?: string;
-}
-```
-
-### Extra Tile Sources
-
-Save additional vector or raster layers (e.g. custom overlays) alongside the style's own sources:
-
-```typescript
-await manager.addRegion({
-  id: 'downtown',
-  name: 'Downtown',
-  bounds: [[-74.05, 40.71], [-74.00, 40.76]],
-  minZoom: 10,
-  maxZoom: 16,
-  styleUrl: 'https://example.com/style.json',
-  extraSources: [
-    {
-      id: 'buildings',
-      type: 'vector',
-      tiles: ['https://tiles.example.com/buildings/{z}/{x}/{y}.pbf'],
-      minzoom: 13,
-      maxzoom: 16,
+  {
+    onProgress: ({ phase, percentage, message }) => {
+      console.log(`[${phase}] ${percentage.toFixed(1)}% ${message ?? ''}`);
     },
-  ],
-});
+  },
+);
+
+// Manage
+await offlineManager.listStoredRegions();
+await offlineManager.getStoredRegion('downtown');
+await offlineManager.deleteRegion('downtown');
+
+// Analytics & cleanup
+await offlineManager.getComprehensiveStorageAnalytics();
+await offlineManager.cleanupExpiredRegions();
+await offlineManager.setupAutoCleanup({ intervalHours: 24, maxAge: 30 });
 ```
 
-When using the `OfflineManagerControl`, the region download form auto-discovers tile sources on the live map and shows them as checkboxes — users pick which extra layers to include.
+### Sparse-source detection
 
-## 🎯 Use Cases
+For composite styles (e.g. Mapbox Standard) that reference sparse tilesets like `indoor-v3` or `landmark-pois-v1`, the tile downloader probes start/middle/end tiles per source and drops any that return majority-404. Disable with `tileOptions: { probeSourcesBeforeDownload: false }`.
 
-- 🏔️ **Outdoor & Recreation Apps**: Hiking, camping, and adventure apps with offline trail maps
-- 📱 **Field Data Collection**: Survey and data collection in remote areas
-- 🚨 **Emergency Response**: Critical map access during network outages
-- ✈️ **Travel Apps**: Tourist apps with offline city maps
-- 🚗 **Fleet Management**: Vehicle tracking with offline map fallback
-- 📊 **Asset Management**: Field service apps with offline capability
-- 🎓 **Educational Apps**: Geography and learning apps with downloadable maps
-- 🏗️ **Construction & Engineering**: Site management with offline blueprints
-- 💾 **Bandwidth Optimization**: Reduce data costs by pre-downloading maps
+### Recovering from an incompatible DB
 
-## 💡 Best Practices
-
-### Performance Optimization
+If another app on the same origin has created `offline-map-db` at a newer version, `dbPromise` throws a typed error. Offer a reset UX:
 
 ```typescript
-// Balance quality vs storage with appropriate zoom levels
-const region = {
-  minZoom: 10, // Don't go too low (tile count grows exponentially)
-  maxZoom: 16, // Don't go too high (diminishing returns)
-  bounds: [
-    /* ... */
-  ],
-};
+import { dbPromise, OfflineMapDBVersionError, resetOfflineMapDB } from 'map-gl-offline';
 
-// Monitor storage usage
-const analytics = await manager.getComprehensiveStorageAnalytics();
-if (analytics.totalStorageSize > 500 * 1024 * 1024) {
-  console.warn('High storage usage detected');
-  await manager.performSmartCleanup({ maxStorageSize: 500 * 1024 * 1024 });
-}
-
-// Use progressive loading for better UX
-const progressiveDownload = {
-  priorityZoomLevels: [12, 13, 11, 14, 10, 15, 16],
-  onProgress: p => updateUI(p),
-};
-```
-
-### Error Handling
-
-```typescript
 try {
-  await manager.addRegion(regionOptions);
-} catch (error) {
-  if (error.message.includes('quota')) {
-    console.error('Storage quota exceeded');
-    await manager.cleanupExpiredRegions();
-  } else if (error.message.includes('network')) {
-    console.error('Network error. Retrying...');
-  } else {
-    console.error('Unexpected error:', error);
+  await dbPromise;
+} catch (err) {
+  if (err instanceof OfflineMapDBVersionError) {
+    if (confirm('Offline storage is incompatible. Clear it?')) {
+      await resetOfflineMapDB(); // destructive
+      location.reload();
+    }
   }
 }
 ```
 
-## 🌐 Browser Compatibility
+## API at a glance
 
-| Browser | Version | Support |
-| ------- | ------- | ------- |
-| Chrome  | 51+     | ✅      |
-| Firefox | 45+     | ✅      |
-| Safari  | 10+     | ✅      |
-| Edge    | 79+     | ✅      |
-| Mobile  | Modern  | ✅      |
+- **Regions** — `downloadRegion`, `loadRegion`, `addRegion`, `getStoredRegion`, `listStoredRegions`, `listRegions`, `deleteRegion`
+- **Analytics** — `getComprehensiveStorageAnalytics`, `getRegionAnalytics`, `getTileStats`, `getFontStats`, `getSpriteStats`, `getGlyphStats`
+- **Cleanup** — `cleanupExpiredRegions`, `performSmartCleanup`, `cleanupOld{Fonts,Sprites,Glyphs}`, `verifyAndRepair{Fonts,Sprites,Glyphs}`, `setupAutoCleanup`, `performCompleteMaintenance`
+- **Import / Export** — `exportRegionAsJSON`, `exportRegionAsPMTiles`, `exportRegionAsMBTiles`, `importRegion`
+- **Storage utilities** — `dbPromise`, `OfflineMapDBVersionError`, `resetOfflineMapDB`, `loadAllStoredRegions`, `resourceKeyBelongsToStyle`
 
-**Requirements:**
+See the **[full API reference](https://map-gl-offline.netlify.app/docs/api-reference)** and **[examples](https://map-gl-offline.netlify.app/docs/examples)** for every option and pattern.
 
-- IndexedDB support
-- ES2015+ JavaScript
-- Async/await support
-- Web Workers (optional, for background tasks)
+## Browser compatibility
 
-## 🤝 Contributing
+Chrome 51+ · Firefox 45+ · Safari 10+ · Edge 79+ · modern mobile browsers. Requires IndexedDB and ES2015+.
 
-Contributions are welcome!
-
-### Development Setup
+## Contributing
 
 ```bash
-# Clone repository
 git clone https://github.com/muimsd/map-gl-offline.git
-cd map-gl-offline
-
-# Install dependencies
-npm install
-
-# Run development server
-npm run dev
-
-# Run tests
-npm test
-
-# Build library
-npm run build
-
-# Run MapLibre example app
-cd examples/maplibre
-npm install
-npm run dev
+cd map-gl-offline && npm install
+npm run dev          # dev harness
+npm test             # unit tests
+npm run build        # library
 ```
 
-### Project Structure
+Issues and PRs welcome. See [CHANGELOG.md](CHANGELOG.md) for release notes.
 
-```
-map-gl-offline/
-├── src/
-│   ├── managers/          # Core offline manager
-│   ├── services/          # Tile, font, sprite services
-│   ├── storage/           # IndexedDB management
-│   ├── ui/                # UI components & controls
-│   │   └── translations/  # i18n (English, Arabic)
-│   ├── utils/             # Utilities & helpers
-│   └── types/             # TypeScript definitions
-├── bin/                   # CLI (map-gl-offline init) & Vite plugin
-├── examples/
-│   ├── maplibre/          # MapLibre GL JS example app
-│   └── mapbox-gl/         # Mapbox GL JS example app
-├── docs/                  # Docusaurus documentation site
-└── tests/                 # Test suites
-```
-
-## 📞 Support & Links
-
-- 📚 [Documentation](https://map-gl-offline.netlify.app)
-- 🎮 [Live Demo](https://map-gl-offline-demo.netlify.app)
-- 🐛 [Report Issues](https://github.com/muimsd/map-gl-offline/issues)
-- 💬 [Discussions](https://github.com/muimsd/map-gl-offline/discussions)
-- ⭐ [Feature Requests](https://github.com/muimsd/map-gl-offline/issues/new)
-- 🌟 [Star on GitHub](https://github.com/muimsd/map-gl-offline)
-
-## 🔄 Recent Updates
-
-See [CHANGELOG.md](CHANGELOG.md) for complete version history.
-
-**v0.5.5 (Latest):** Extra tile source selection for offline regions — pick additional vector/raster layers to download alongside the style's own sources.
-
-**v0.5.3:** 28% bundle size reduction (783 KB to 565 KB), 20+ bug fixes, XSS prevention, import atomicity, `@/` path alias for all imports.
-
-**v0.5.2:** CLI command (`npx map-gl-offline init`), Vite plugin for Service Worker, Mapbox GL example app.
-
-**v0.5.0:** Mapbox GL JS support, Standard style with 3D/terrain, day/night presets, rain/snow, i18n (English & Arabic with RTL).
-
-## 🙏 Acknowledgments
-
-- [MapLibre GL JS](https://github.com/maplibre/maplibre-gl-js) - Open-source map rendering engine
-- [Mapbox GL JS](https://github.com/mapbox/mapbox-gl-js) - Commercial map rendering engine
-- [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API) - Browser storage API
-- [Tilebelt](https://github.com/mapbox/tilebelt) - Tile coordinate utilities
-- [Tailwind CSS](https://tailwindcss.com/) - Utility-first CSS framework
-
-## 📄 License
+## License
 
 MIT © [Muhammad Imran Siddique](https://github.com/muimsd)
 
@@ -548,10 +194,8 @@ MIT © [Muhammad Imran Siddique](https://github.com/muimsd)
 
 <div align="center">
 
-**Made with ❤️ for the mapping community**
+[📖 Docs](https://map-gl-offline.netlify.app) · [🎮 Demo](https://map-gl-offline-demo.netlify.app) · [⭐ GitHub](https://github.com/muimsd/map-gl-offline)
 
-[📖 Documentation](https://map-gl-offline.netlify.app) • [🎮 Live Demo](https://map-gl-offline-demo.netlify.app) • [⭐ Star on GitHub](https://github.com/muimsd/map-gl-offline)
-
-<a href="https://www.buymeacoffee.com/muimsd" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;" ></a>
+<a href="https://www.buymeacoffee.com/muimsd" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" style="height: 45px;"></a>
 
 </div>

--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -25,11 +25,53 @@ The constructor accepts optional service overrides for dependency injection (adv
 
 ### Region Management Methods
 
-#### `addRegion(options: OfflineRegionOptions): Promise<void>`
+#### `downloadRegion(region: OfflineRegionOptions, options?: DownloadRegionOptions): Promise<DownloadRegionResult>`
 
-Download and store a map region for offline use.
+Run the full offline-region pipeline: downloads the style (if not already stored), sprites, glyphs, tiles, then persists region metadata. Progress is reported per phase via `options.onProgress`.
 
 ```typescript
+await manager.downloadRegion(
+  {
+    id: 'my-region',
+    name: 'My Region',
+    bounds: [[-74.05, 40.71], [-74.00, 40.76]],
+    minZoom: 10,
+    maxZoom: 16,
+    styleUrl: 'https://example.com/style.json',
+  },
+  {
+    onProgress: ({ phase, completed, total, percentage, message }) => {
+      // phase: 'style' | 'sprites' | 'glyphs' | 'tiles' | 'metadata'
+      console.log(`[${phase}] ${completed}/${total} (${percentage.toFixed(1)}%)`);
+    },
+  },
+);
+```
+
+**`DownloadRegionOptions`:**
+
+| Option | Type | Description |
+|---|---|---|
+| `onProgress` | `(p: DownloadRegionProgress) => void` | Called with `{ phase, completed, total, percentage, message? }` during each phase. |
+| `provider` | `'auto' \| 'mapbox' \| 'maplibre'` | Style provider hint when fetching the style. Defaults to `'auto'`. |
+| `accessToken` | `string` | Mapbox access token; required for `mapbox://` URLs. |
+| `skipSprites` | `boolean` | Skip the sprite-download phase. Default `false`. |
+| `skipGlyphs` | `boolean` | Skip the glyph-download phase. Default `false`. |
+| `glyphRanges` | `string[]` | Override Unicode glyph ranges. Defaults to `GLYPH_CONFIG.COMPREHENSIVE_RANGES`. |
+| `tileOptions` | `TileDownloadOptions` | Forwarded to the tile download step (e.g. `probeSourcesBeforeDownload`, `batchSize`). |
+
+**`DownloadRegionResult`** includes `regionId`, `styleId`, `styleResult?`, `spriteResults`, `glyphResult?`, and `tileResult`.
+
+#### `loadRegion(region: OfflineRegionOptions, options?: DownloadRegionOptions): Promise<DownloadRegionResult>`
+
+Alias for `downloadRegion`. Kept for naming parity with native offline APIs.
+
+#### `addRegion(options: OfflineRegionOptions): Promise<void>`
+
+Store region metadata inside its style entry and patch the style's URLs to `idb://` for offline use. Does **not** fetch tiles, sprites, or glyphs — for the full pipeline, use `downloadRegion`. The region's `expiry`, if supplied, is stored as an absolute timestamp (ms since epoch); omit it to default to 30 days from now. If a region with the same `id` already exists on the style it is replaced in place (`created` preserved, `updated` refreshed).
+
+```typescript
+// Metadata-only; style must already be downloaded.
 await manager.addRegion({
   id: 'my-region',
   name: 'My Region',
@@ -37,14 +79,13 @@ await manager.addRegion({
   minZoom: 10,
   maxZoom: 16,
   styleUrl: 'https://example.com/style.json',
-  onProgress: (progress) => console.log(progress.percentage),
 });
 ```
 
-You can also include additional tile sources that are not part of the style:
+Both `addRegion` and `downloadRegion` accept `extraSources` for additional tile sources not declared by the style:
 
 ```typescript
-await manager.addRegion({
+await manager.downloadRegion({
   id: 'my-region',
   name: 'My Region',
   bounds: [[-74.05, 40.71], [-74.00, 40.76]],
@@ -187,6 +228,59 @@ Get sprite statistics aggregated across all styles.
 #### `getGlyphStats(): Promise<EnhancedGlyphStats>`
 
 Get glyph statistics aggregated across all styles.
+
+### Tile Download Options
+
+Options that `downloadRegion` forwards to the tile downloader (or that you can pass directly to `downloadTiles` / `ResourceService.downloadTilesWithOptions`).
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `probeSourcesBeforeDownload` | `boolean` | `true` | Fetch 3 representative tiles (start, middle, end) per source before committing its full plan. Majority-404 sources are dropped entirely. Keeps the console clean for composite styles (e.g. Mapbox Standard) that reference sparse tilesets like `indoor-v3` or `landmark-pois-v1` that only have data at specific locations. |
+| `skipExisting` | `boolean` | `true` | Skip tiles already present in IndexedDB. |
+| `batchSize` | `number` | `10` | Concurrent tiles per batch. |
+| `maxRetries` | `number` | `3` | Per-tile retry count before giving up. |
+| `timeout` | `number` | `10000` | Per-tile fetch timeout in ms. |
+| `retryDelay` | `number` | `1000` | Base delay between retries. |
+| `bandwidthLimit` | `number` | — | KB/s ceiling to throttle downloads. |
+| `validateTiles` | `boolean` | `false` | Validate tile payloads after download. |
+| `compressTiles` | `boolean` | `false` | Compress tiles before storage. |
+| `priorityZoomLevels` | `number[]` | `[]` | Download these zoom levels first. |
+| `storageQuotaCheck` | `boolean` | `true` | Refuse to start if available storage is below the safety floor. |
+
+### Storage Resilience
+
+Top-level exports for handling incompatible on-disk state (e.g. after a version downgrade, or when another app shares the IDB name on the same origin).
+
+#### `OfflineMapDBVersionError`
+
+Typed subclass of `Error` thrown from `dbPromise` when the existing database schema is newer than this build supports. Exposes `requestedVersion` and `existingVersion` fields and a message referencing the recovery helper.
+
+#### `resetOfflineMapDB(): Promise<void>`
+
+Destructive helper that deletes the `offline-map-db` IndexedDB database and all stored offline data. Intended as the recovery path after catching an `OfflineMapDBVersionError`.
+
+```typescript
+import { dbPromise, OfflineMapDBVersionError, resetOfflineMapDB } from 'map-gl-offline';
+
+try {
+  await dbPromise;
+} catch (err) {
+  if (err instanceof OfflineMapDBVersionError) {
+    if (confirm('Offline storage is incompatible. Clear it?')) {
+      await resetOfflineMapDB();
+      location.reload();
+    }
+  }
+}
+```
+
+#### `loadAllStoredRegions(): Promise<StoredRegion[]>`
+
+Flatten every stored style's `regions[]` into a single `StoredRegion[]` (populated with `key`, `styleId`, `created`, `lastModified`, `expiry`). Shared by `RegionService.listStoredRegions` and `CleanupService.getAllRegions`; exposed publicly for advanced callers that want direct DB access.
+
+#### `resourceKeyBelongsToStyle(key: string, styleId: string): boolean`
+
+Delimiter-aware prefix match used by the cleanup paths. Returns `true` for `styleId` or `styleId:…` (the canonical key format) but not for sibling styles that share a prefix (e.g. `"abc_def:foo"` does not belong to style `"abc"`). Fixes a long-standing data-loss bug in resource cleanup.
 
 ### Import/Export Methods
 

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -43,27 +43,33 @@ const control = new OfflineManagerControl(offlineManager, {
 When downloading a region, you can configure various options:
 
 ```typescript
-await manager.addRegion({
-  // Required
-  id: 'unique-region-id',
-  name: 'Human Readable Name',
-  bounds: [[-74.05, 40.71], [-74.00, 40.76]], // [[west, south], [east, north]]
-  minZoom: 10,
-  maxZoom: 16,
+await manager.downloadRegion(
+  {
+    // Required
+    id: 'unique-region-id',
+    name: 'Human Readable Name',
+    bounds: [[-74.05, 40.71], [-74.00, 40.76]], // [[west, south], [east, north]]
+    minZoom: 10,
+    maxZoom: 16,
 
-  // Optional
-  styleUrl: 'https://example.com/style.json',
-  expiry: Date.now() + 30 * 24 * 60 * 60 * 1000, // 30 days from now
-  deleteOnExpiry: true,
-  multipleRegions: false,
-  tileExtension: 'pbf', // default: auto-detected from style
-
-  // Callbacks
-  onProgress: (progress) => {
-    console.log(`${progress.percentage}% - ${progress.message}`);
+    // Optional
+    styleUrl: 'https://example.com/style.json',
+    expiry: Date.now() + 30 * 24 * 60 * 60 * 1000, // absolute timestamp (ms since epoch)
+    deleteOnExpiry: true,
+    multipleRegions: false,
+    // tileExtension: 'pbf' — Usually unnecessary; the style patcher extracts
+    // per-source extensions from tile URL patterns. Only set this when you
+    // need to force one extension for every source in the region.
   },
-});
+  {
+    onProgress: ({ phase, percentage, message }) => {
+      console.log(`[${phase}] ${percentage.toFixed(1)}% - ${message ?? ''}`);
+    },
+  },
+);
 ```
+
+> `addRegion` is still available for callers that want to record metadata without downloading assets (e.g., after a manual tile import). Most callers should use `downloadRegion`.
 
 See the [API Reference](./api-reference#offlineregionoptions) for the full `OfflineRegionOptions` type definition.
 

--- a/docs/docs/examples.md
+++ b/docs/docs/examples.md
@@ -48,22 +48,27 @@ map.addControl(control, 'top-right');
 
 ### Programmatic Download
 
+Call `downloadRegion` to run the full pipeline (style → sprites → glyphs → tiles → metadata) with per-phase progress. `addRegion` on its own only stores metadata.
+
 ```typescript
 const manager = new OfflineMapManager();
 
-// Download New York City area
-await manager.addRegion({
-  id: 'nyc',
-  name: 'New York City',
-  bounds: [[-74.259, 40.477], [-73.700, 40.917]],
-  minZoom: 10,
-  maxZoom: 15,
-  styleUrl: 'https://api.maptiler.com/maps/streets/style.json?key=YOUR_KEY',
-  onProgress: (progress) => {
-    updateProgressBar(progress.percentage);
-    updateStatusText(progress.message);
+await manager.downloadRegion(
+  {
+    id: 'nyc',
+    name: 'New York City',
+    bounds: [[-74.259, 40.477], [-73.700, 40.917]],
+    minZoom: 10,
+    maxZoom: 15,
+    styleUrl: 'https://api.maptiler.com/maps/streets/style.json?key=YOUR_KEY',
   },
-});
+  {
+    onProgress: ({ phase, percentage, message }) => {
+      updateProgressBar(percentage);
+      updateStatusText(`[${phase}] ${message ?? ''}`);
+    },
+  },
+);
 ```
 
 ---
@@ -121,17 +126,25 @@ const control = new OfflineManagerControl(manager, {
 
 map.addControl(control, 'top-right');
 
-// Download a region with 3D buildings
-await manager.addRegion({
-  id: 'manhattan-3d',
-  name: 'Manhattan 3D',
-  bounds: [[-74.02, 40.70], [-73.95, 40.78]],
-  minZoom: 12,
-  maxZoom: 16,
-  styleUrl: 'mapbox://styles/mapbox/standard',
-  accessToken: mapboxgl.accessToken,
-  onProgress: (p) => console.log(`${p.percentage}%`),
-});
+// Download a region with 3D buildings. The tile downloader probes each
+// source before committing — sparse Mapbox tilesets (indoor, landmark-POIs,
+// procedural-buildings) that return 404 for most coordinates are
+// automatically dropped, keeping the console clean.
+await manager.downloadRegion(
+  {
+    id: 'manhattan-3d',
+    name: 'Manhattan 3D',
+    bounds: [[-74.02, 40.70], [-73.95, 40.78]],
+    minZoom: 12,
+    maxZoom: 16,
+    styleUrl: 'mapbox://styles/mapbox/standard',
+  },
+  {
+    accessToken: mapboxgl.accessToken,
+    provider: 'mapbox',
+    onProgress: ({ phase, percentage }) => console.log(`[${phase}] ${percentage.toFixed(0)}%`),
+  },
+);
 ```
 
 ### Day/Night Light Presets
@@ -188,7 +201,7 @@ Save additional vector or raster tile layers alongside the style's own sources. 
 ### Download Region with Extra Vector Layers
 
 ```typescript
-await manager.addRegion({
+await manager.downloadRegion({
   id: 'downtown-with-layers',
   name: 'Downtown + Custom Layers',
   bounds: [[-74.05, 40.71], [-74.00, 40.76]],
@@ -233,7 +246,7 @@ const extraSources = Object.entries(style.sources)
   });
 
 // Use the extracted sources in a region download
-await manager.addRegion({
+await manager.downloadRegion({
   id: 'full-offline',
   name: 'Full Offline Region',
   bounds: [[-74.05, 40.71], [-74.00, 40.76]],
@@ -274,13 +287,17 @@ const regions = [
 ];
 
 for (const region of regions) {
-  await manager.addRegion({
-    ...region,
-    minZoom: 10,
-    maxZoom: 14,
-    styleUrl: STYLE_URL,
-    onProgress: (p) => console.log(`${region.name}: ${p.percentage}%`),
-  });
+  await manager.downloadRegion(
+    {
+      ...region,
+      minZoom: 10,
+      maxZoom: 14,
+      styleUrl: STYLE_URL,
+    },
+    {
+      onProgress: ({ percentage }) => console.log(`${region.name}: ${percentage.toFixed(0)}%`),
+    },
+  );
 }
 ```
 
@@ -610,7 +627,7 @@ async function downloadWithRetry(regionOptions: OfflineRegionOptions, maxRetries
 
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
-      await manager.addRegion(regionOptions);
+      await manager.downloadRegion(regionOptions);
       return; // Success
     } catch (error) {
       lastError = error as Error;
@@ -655,7 +672,7 @@ function sleep(ms: number): Promise<void> {
 ```typescript
 async function downloadRegion(options: OfflineRegionOptions) {
   try {
-    await manager.addRegion(options);
+    await manager.downloadRegion(options);
     showToast('Region downloaded successfully!', 'success');
   } catch (error) {
     const message = getUserErrorMessage(error);
@@ -756,11 +773,10 @@ class DownloadProgressUI {
     this.updatePhase('Preparing...');
 
     try {
-      await manager.addRegion({
-        ...options,
+      await manager.downloadRegion(options, {
         onProgress: (progress) => {
           this.updateProgress(progress.percentage);
-          this.updatePhase(progress.message || 'Downloading...');
+          this.updatePhase(progress.message || `Downloading ${progress.phase}...`);
           this.updateDetails(`${progress.completed}/${progress.total}`);
         },
       });
@@ -829,7 +845,7 @@ async function downloadPreset(presetId: keyof typeof REGION_PRESETS) {
   const preset = REGION_PRESETS[presetId];
   if (!preset) throw new Error(`Unknown preset: ${presetId}`);
 
-  await manager.addRegion({
+  await manager.downloadRegion({
     id: presetId,
     ...preset,
     styleUrl: STYLE_URL,
@@ -862,7 +878,7 @@ class RegionSync {
     for (const serverRegion of serverRegions) {
       if (!localIds.has(serverRegion.id)) {
         console.log(`Downloading missing region: ${serverRegion.name}`);
-        await this.manager.addRegion(serverRegion);
+        await this.manager.downloadRegion(serverRegion);
       }
     }
   }

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -187,26 +187,30 @@ The built-in UI control provides:
 
 ## Programmatic Usage (No UI)
 
-For more control, use the `OfflineMapManager` directly:
+For more control, use the `OfflineMapManager` directly. Call `downloadRegion` to run the full pipeline (style → sprites → glyphs → tiles → metadata):
 
 ```typescript
 const offlineManager = new OfflineMapManager();
 
-// Download a region
-await offlineManager.addRegion({
-  id: 'downtown',
-  name: 'Downtown Area',
-  bounds: [
-    [-74.0559, 40.7128], // Southwest [lng, lat]
-    [-74.0059, 40.7628], // Northeast [lng, lat]
-  ],
-  minZoom: 10,
-  maxZoom: 16,
-  styleUrl: 'https://api.maptiler.com/maps/streets/style.json?key=YOUR_KEY',
-  onProgress: (progress) => {
-    console.log(`Progress: ${progress.percentage}%`);
+// Download a region end-to-end
+await offlineManager.downloadRegion(
+  {
+    id: 'downtown',
+    name: 'Downtown Area',
+    bounds: [
+      [-74.0559, 40.7128], // Southwest [lng, lat]
+      [-74.0059, 40.7628], // Northeast [lng, lat]
+    ],
+    minZoom: 10,
+    maxZoom: 16,
+    styleUrl: 'https://api.maptiler.com/maps/streets/style.json?key=YOUR_KEY',
   },
-});
+  {
+    onProgress: ({ phase, percentage }) => {
+      console.log(`[${phase}] ${percentage.toFixed(1)}%`);
+    },
+  },
+);
 
 // List stored regions
 const regions = await offlineManager.listStoredRegions();


### PR DESCRIPTION
## Summary

Updates the docs to cover everything added in the two recently-merged PRs and shrinks the README from 587 → 201 lines.

### From PR #19 (programmatic region download + dedup)

- `downloadRegion(region, options?)` — full pipeline with per-phase progress
- `loadRegion` alias
- Clarified that `addRegion` is metadata-only

### From PR #20 (audit fixes + probe + storage resilience)

- `probeSourcesBeforeDownload` tile option (multi-probe start/middle/end, majority-rule)
- `OfflineMapDBVersionError` + `resetOfflineMapDB()` helpers
- `loadAllStoredRegions()` / `resourceKeyBelongsToStyle()` exports
- `expiry` clarified as absolute timestamp

## Doc surface updates

- **`docs/docs/api-reference.md`** — new `downloadRegion` section with `DownloadRegionOptions` table, `loadRegion` alias, clarified `addRegion` semantics, new Tile Download Options table, new Storage Resilience section.
- **`docs/docs/getting-started.md`** — programmatic quick-start switched to `downloadRegion`.
- **`docs/docs/examples.md`** — top-level programmatic examples switched to `downloadRegion` (extra layers, multi-region loop, retry/error, progress controller, presets, sync). UI-flow examples untouched.
- **`docs/docs/configuration.md`** — `OfflineRegionOptions` example updated; note added about absolute `expiry` and auto-detected `tileExtension`.

## README shrink

From 587 → 201 lines. Removed overlong feature breakdowns, inline API reference (duplicated the docs site), verbose Analytics/Cleanup/Error-handling examples, and the project-structure tree. Kept: install, MapLibre/Mapbox quick-start, a programmatic snippet, DB-version-error recovery, sparse-source probe paragraph, "API at a glance" bullets with deep-links to the docs site.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` no new warnings (pre-existing `any` warning in `offlineManagerControl.ts` untouched)
- [x] `npm test` 1392/1392 unit tests pass (5 pre-existing e2e failures that need a running dev server, unrelated)
- [x] `prettier --check` clean

No source or test changes — docs only.