### PR TITLE
feat(mapbox-standard): full offline support — models + raster-array + iconset

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,7 @@ export * from './services/tileService';
 export * from './services/fontService';
 export * from './services/glyphService';
 export * from './services/spriteService';
+export * from './services/modelService';
 export * from './services/cleanupService';
 export * from './services/styleService';
 export * from './services/regionService';

--- a/src/managers/offlineMapManager/resourceManagement.ts
+++ b/src/managers/offlineMapManager/resourceManagement.ts
@@ -22,6 +22,10 @@ export interface ResourceManagement {
   loadGlyphsForStyle: ResourceService['loadGlyphsForStyle'];
   cleanupOldGlyphs: ResourceService['cleanupOldGlyphs'];
   verifyAndRepairGlyphs: ResourceService['verifyAndRepairGlyphs'];
+  downloadModelsWithOptions: ResourceService['downloadModelsWithOptions'];
+  getModelStats: ResourceService['getModelStats'];
+  cleanupOldModels: ResourceService['cleanupOldModels'];
+  verifyAndRepairModels: ResourceService['verifyAndRepairModels'];
 }
 
 export const createResourceManagement = (services: OfflineManagerServices): ResourceManagement => ({
@@ -45,4 +49,9 @@ export const createResourceManagement = (services: OfflineManagerServices): Reso
   loadGlyphsForStyle: (...args) => services.resourceService.loadGlyphsForStyle(...args),
   cleanupOldGlyphs: (...args) => services.resourceService.cleanupOldGlyphs(...args),
   verifyAndRepairGlyphs: (...args) => services.resourceService.verifyAndRepairGlyphs(...args),
+  downloadModelsWithOptions: (...args) =>
+    services.resourceService.downloadModelsWithOptions(...args),
+  getModelStats: (...args) => services.resourceService.getModelStats(...args),
+  cleanupOldModels: (...args) => services.resourceService.cleanupOldModels(...args),
+  verifyAndRepairModels: (...args) => services.resourceService.verifyAndRepairModels(...args),
 });

--- a/src/services/modelService.ts
+++ b/src/services/modelService.ts
@@ -1,0 +1,233 @@
+import { dbPromise } from '@/storage/indexedDbManager';
+import { fetchResourceWithRetry, processBatch, createProgressTracker, logger } from '@/utils';
+import type {
+  ModelEntry,
+  ModelDownloadOptions,
+  ModelDownloadResult,
+  EnhancedModelStats,
+} from '@/types';
+
+const modelLogger = logger.scope('ModelService');
+
+/**
+ * Build the storage key for a model. Kept consistent with sprite/glyph
+ * conventions: `{styleId}::model::{modelName}`.
+ */
+function modelKey(styleId: string, modelName: string): string {
+  return `${styleId}::model::${modelName}`;
+}
+
+/** True when the given key belongs to the given styleId's model store prefix. */
+export function modelKeyBelongsToStyle(key: string, styleId: string): boolean {
+  return key.startsWith(`${styleId}::model::`);
+}
+
+/**
+ * Service for downloading, storing, and serving Mapbox 3D model (.glb) files.
+ *
+ * Mapbox Standard declares 32 models at the top of `style.models`:
+ *
+ * ```json
+ * {
+ *   "maple1-lod1": "mapbox://models/mapbox/maple1-v4-lod1.glb",
+ *   ...
+ * }
+ * ```
+ *
+ * `model` layers (e.g. `trees`, `wind-turbine-towers`) pick one by name at
+ * render time. For offline use each referenced URL is fetched and stored
+ * here, and `patchStyleForOffline` rewrites the dictionary entries to
+ * `idb://{styleId}/model/{name}` URLs.
+ */
+export class ModelService {
+  private db = dbPromise;
+
+  /**
+   * Download the set of models referenced by `style.models` for one style.
+   *
+   * @param models   `{ modelName: resolvedHttpUrl }` — URLs must already be
+   *                 resolved (mapbox:// URLs should be resolved by the caller).
+   * @param styleId  The owning style's key.
+   */
+  async downloadModels(
+    models: Record<string, string>,
+    styleId: string,
+    options: ModelDownloadOptions = {}
+  ): Promise<ModelDownloadResult> {
+    const db = await this.db;
+    const {
+      onProgress,
+      batchSize = 4,
+      maxRetries = 3,
+      skipExisting = true,
+      timeoutMs = 30000,
+    } = options;
+
+    const entries = Object.entries(models);
+    const progressTracker = createProgressTracker(entries.length);
+    const result: ModelDownloadResult = {
+      totalModels: entries.length,
+      downloadedModels: 0,
+      skippedModels: 0,
+      failedModels: 0,
+      totalSize: 0,
+      errors: [],
+    };
+
+    const emit = () => onProgress?.(progressTracker.getProgress());
+    emit();
+
+    if (entries.length === 0) return result;
+
+    // Pre-compute existing keys for skipExisting
+    const existingKeys = new Set<string>();
+    if (skipExisting) {
+      const tx = db.transaction('models', 'readonly');
+      for await (const cursor of tx.store) {
+        existingKeys.add(cursor.value.key);
+      }
+    }
+
+    await processBatch(
+      entries,
+      async ([modelName, url]) => {
+        const key = modelKey(styleId, modelName);
+        const label = `${styleId}::${modelName}`;
+
+        if (skipExisting && existingKeys.has(key)) {
+          result.skippedModels++;
+          progressTracker.update(1, label);
+          emit();
+          return;
+        }
+
+        try {
+          const response = await fetchResourceWithRetry(url, {
+            retries: maxRetries,
+            timeout: timeoutMs,
+            proxyType: 'tiles',
+          });
+          if (response.type === 'json') {
+            throw new Error('Unexpected JSON response for model');
+          }
+          const data = response.data;
+          const contentType =
+            ('contentType' in response && response.contentType) || 'model/gltf-binary';
+
+          const entry: ModelEntry = {
+            key,
+            data,
+            contentType,
+            size: data.byteLength,
+            url,
+            styleId,
+            modelName,
+            lastModified: Date.now(),
+            downloadedAt: new Date().toISOString(),
+            expires: response.expires,
+          };
+          await db.put('models', entry);
+          result.downloadedModels++;
+          result.totalSize += data.byteLength;
+          progressTracker.update(1, label);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          result.failedModels++;
+          result.errors.push({ url, error: message });
+          modelLogger.warn(`Failed to download model "${modelName}" from ${url}:`, err);
+          progressTracker.update(1, label, message);
+        }
+        emit();
+      },
+      { batchSize }
+    );
+
+    modelLogger.info(
+      `Models downloaded for style ${styleId}: ${result.downloadedModels} new, ${result.skippedModels} skipped, ${result.failedModels} failed`
+    );
+    return result;
+  }
+
+  /** Retrieve a single model by `{styleId, modelName}`. */
+  async getModel(styleId: string, modelName: string): Promise<ModelEntry | undefined> {
+    const db = await this.db;
+    return db.get('models', modelKey(styleId, modelName));
+  }
+
+  /** Aggregate stats across all stored models. */
+  async getModelStats(): Promise<EnhancedModelStats> {
+    const db = await this.db;
+    const stats: EnhancedModelStats = {
+      count: 0,
+      totalSize: 0,
+      averageSize: 0,
+      models: [],
+      modelsByStyle: {},
+    };
+    const tx = db.transaction('models', 'readonly');
+    for await (const cursor of tx.store) {
+      const m = cursor.value;
+      stats.count++;
+      stats.totalSize += m.size;
+      stats.models.push({ name: m.modelName, size: m.size, lastModified: m.lastModified });
+      stats.modelsByStyle[m.styleId] = (stats.modelsByStyle[m.styleId] ?? 0) + 1;
+    }
+    stats.averageSize = stats.count > 0 ? stats.totalSize / stats.count : 0;
+    return stats;
+  }
+
+  /**
+   * Delete models older than `maxAge` days. Defaults to 30.
+   */
+  async cleanupOldModels(maxAge: number = 30): Promise<number> {
+    const db = await this.db;
+    const cutoff = Date.now() - maxAge * 24 * 60 * 60 * 1000;
+    let deleted = 0;
+    const tx = db.transaction('models', 'readwrite');
+    for await (const cursor of tx.store) {
+      if (cursor.value.lastModified < cutoff) {
+        await cursor.delete();
+        deleted++;
+      }
+    }
+    return deleted;
+  }
+
+  /**
+   * Basic integrity check: remove entries with empty/missing data.
+   */
+  async verifyAndRepairModels(): Promise<{ verified: number; repaired: number; removed: number }> {
+    const db = await this.db;
+    let verified = 0;
+    let removed = 0;
+    const tx = db.transaction('models', 'readwrite');
+    for await (const cursor of tx.store) {
+      const m = cursor.value;
+      if (!m.data || m.data.byteLength === 0) {
+        await cursor.delete();
+        removed++;
+      } else {
+        verified++;
+      }
+    }
+    return { verified, repaired: 0, removed };
+  }
+}
+
+// Singleton + convenience exports, matching other service modules.
+export const modelService = new ModelService();
+
+export const downloadModels = (
+  models: Record<string, string>,
+  styleId: string,
+  options?: ModelDownloadOptions
+) => modelService.downloadModels(models, styleId, options);
+
+export const getModel = (styleId: string, modelName: string) =>
+  modelService.getModel(styleId, modelName);
+
+export const getModelStats = () => modelService.getModelStats();
+
+export const cleanupOldModels = (maxAge?: number) => modelService.cleanupOldModels(maxAge);
+
+export const verifyAndRepairModels = () => modelService.verifyAndRepairModels();

--- a/src/services/regionService.ts
+++ b/src/services/regionService.ts
@@ -388,8 +388,13 @@ export class RegionService {
       const spriteSources = normalizeSpriteProperty(originalSpriteUrl);
       if (spriteSources.length > 0) {
         const { downloadSprites } = await import('@/services/spriteService');
-        const suffixes = ['.json', '.png', '@2x.json', '@2x.png'];
-        const totalFiles = spriteSources.length * suffixes.length;
+        // Standard four sprite variants. For Mapbox Standard, an `iconset.pbf`
+        // sibling is also served under the same /styles/v1/.../<hash>/ path
+        // — we detect that case per-source below and append it to the list.
+        const baseSuffixes = ['.json', '.png', '@2x.json', '@2x.png'];
+        // Estimate total files assuming iconset is always included (the actual
+        // number may be smaller; the emit helper clamps progress to total).
+        const totalFiles = spriteSources.length * (baseSuffixes.length + 1);
         let completed = 0;
         emit('sprites', 0, totalFiles, 'Downloading sprites');
 
@@ -399,11 +404,29 @@ export class RegionService {
             spriteBase = resolveMapboxUrl(spriteBase, effectiveAccessToken);
           }
           const qIndex = spriteBase.indexOf('?');
-          const spriteUrls = suffixes.map(suffix =>
-            qIndex !== -1
-              ? spriteBase.slice(0, qIndex) + suffix + spriteBase.slice(qIndex)
-              : spriteBase + suffix
+          const suffixes = [...baseSuffixes];
+          // Mapbox Standard serves an iconset.pbf alongside the sprite under
+          // /styles/v1/{owner}/{style}/{hash}/sprite → the sibling file is
+          // /styles/v1/{owner}/{style}/{hash}/iconset.pbf. The last path
+          // segment is `sprite`, so replacing it with `iconset.pbf` works.
+          const pathWithoutQuery = qIndex !== -1 ? spriteBase.slice(0, qIndex) : spriteBase;
+          const isMapboxStandardSprite = /api\.mapbox\.com\/styles\/v1\/.+\/sprite$/.test(
+            pathWithoutQuery
           );
+          if (isMapboxStandardSprite) {
+            // The path-rewrite suffix replaces the trailing `sprite` segment.
+            suffixes.push('__ICONSET__');
+          }
+          const spriteUrls = suffixes.map(suffix => {
+            if (suffix === '__ICONSET__') {
+              // Replace trailing `sprite` with `iconset.pbf`, preserving query.
+              const base = pathWithoutQuery.replace(/sprite$/, 'iconset.pbf');
+              return qIndex !== -1 ? base + spriteBase.slice(qIndex) : base;
+            }
+            return qIndex !== -1
+              ? spriteBase.slice(0, qIndex) + suffix + spriteBase.slice(qIndex)
+              : spriteBase + suffix;
+          });
           try {
             const result = await downloadSprites(spriteUrls, styleId, {
               enableValidation: true,

--- a/src/services/regionService.ts
+++ b/src/services/regionService.ts
@@ -173,8 +173,17 @@ export class RegionService {
       }
     }
 
+    let deletedModels = 0;
+    const modelTx = db.transaction('models', 'readwrite');
+    for await (const cursor of modelTx.store) {
+      if (resourceKeyBelongsToStyle(cursor.value.key, styleId)) {
+        await cursor.delete();
+        deletedModels++;
+      }
+    }
+
     regionLogger.info(
-      `Deleted style resources: ${deletedFonts} fonts, ${deletedGlyphs} glyphs, ${deletedSprites} sprites`
+      `Deleted style resources: ${deletedFonts} fonts, ${deletedGlyphs} glyphs, ${deletedSprites} sprites, ${deletedModels} models`
     );
   }
 
@@ -322,6 +331,7 @@ export class RegionService {
       accessToken,
       skipGlyphs = false,
       skipSprites = false,
+      skipModels = false,
       glyphRanges,
       tileOptions,
     } = options;
@@ -479,7 +489,41 @@ export class RegionService {
       }
     }
 
-    // 4. Tiles — use the stored (source-embedded) style, which still has HTTP tile URLs
+    // 4. Models — Mapbox Standard's `style.models` references 3D tree /
+    //    turbine .glb assets. Two value shapes exist in the wild
+    //    (plain string or `{ uri }`) — we accept both.
+    let modelResult: DownloadRegionResult['modelResult'];
+    if (!skipModels && storedStyle.models) {
+      const rawModels = storedStyle.models as Record<string, string | { uri?: string }>;
+      const resolved: Record<string, string> = {};
+      for (const [name, value] of Object.entries(rawModels)) {
+        const uri = typeof value === 'string' ? value : value?.uri;
+        if (!uri) continue;
+        if (uri.startsWith('idb://')) continue; // already patched
+        const httpUrl =
+          isMapboxProtocol(uri) && effectiveAccessToken
+            ? resolveMapboxUrl(uri, effectiveAccessToken)
+            : uri;
+        if (httpUrl.startsWith('http://') || httpUrl.startsWith('https://')) {
+          resolved[name] = httpUrl;
+        }
+      }
+      if (Object.keys(resolved).length > 0) {
+        const { downloadModels } = await import('@/services/modelService');
+        emit('models', 0, Object.keys(resolved).length, 'Downloading 3D models');
+        try {
+          modelResult = await downloadModels(resolved, styleId, {
+            onProgress: (progress: { completed: number; total: number }) => {
+              emit('models', progress.completed, progress.total, 'Downloading 3D models');
+            },
+          });
+        } catch (error) {
+          regionLogger.warn('Model download failed (non-fatal):', error);
+        }
+      }
+    }
+
+    // 5. Tiles — use the stored (source-embedded) style, which still has HTTP tile URLs
     const { downloadTiles } = await import('@/services/tileService');
     const regionForTiles = { ...region, styleId };
     emit('tiles', 0, 100, 'Downloading tiles');
@@ -493,7 +537,7 @@ export class RegionService {
       },
     });
 
-    // 5. Metadata — must run last, since addRegion patches style URLs to idb://.
+    // 6. Metadata — must run last, since addRegion patches style URLs to idb://.
     // Do NOT auto-fill tileExtension from tileResult: that's only the first
     // source's extension, and addRegion feeds it to patchStyleForOffline which
     // would override ALL sources — breaking mixed raster+vector styles. The
@@ -510,6 +554,7 @@ export class RegionService {
       styleResult,
       spriteResults,
       glyphResult,
+      modelResult,
       tileResult,
     };
   }

--- a/src/services/resourceService.ts
+++ b/src/services/resourceService.ts
@@ -22,6 +22,12 @@ import {
   verifyAndRepairGlyphs,
   EnhancedGlyphStats,
 } from './glyphService';
+import {
+  downloadModels,
+  getModelStats,
+  cleanupOldModels,
+  verifyAndRepairModels,
+} from './modelService';
 import type {
   OfflineRegionOptions,
   MapboxStyle,
@@ -36,6 +42,9 @@ import type {
   EnhancedFontStats,
   GlyphDownloadOptions,
   GlyphDownloadResult,
+  ModelDownloadOptions,
+  ModelDownloadResult,
+  EnhancedModelStats,
 } from '@/types';
 
 export class ResourceService {
@@ -143,5 +152,27 @@ export class ResourceService {
 
   async verifyAndRepairGlyphs(): Promise<{ verified: number; repaired: number; removed: number }> {
     return verifyAndRepairGlyphs();
+  }
+
+  // 3D Model Management Methods
+
+  async downloadModelsWithOptions(
+    models: Record<string, string>,
+    styleId: string,
+    options: ModelDownloadOptions = {}
+  ): Promise<ModelDownloadResult> {
+    return downloadModels(models, styleId, options);
+  }
+
+  async getModelStats(): Promise<EnhancedModelStats> {
+    return getModelStats();
+  }
+
+  async cleanupOldModels(options?: { maxAge?: number }): Promise<number> {
+    return cleanupOldModels(options?.maxAge);
+  }
+
+  async verifyAndRepairModels(): Promise<{ verified: number; repaired: number; removed: number }> {
+    return verifyAndRepairModels();
   }
 }

--- a/src/services/tileService.ts
+++ b/src/services/tileService.ts
@@ -750,11 +750,16 @@ export class TileService {
         url: config.url,
       });
 
-      // Handle tile-based sources (vector, raster, raster-dem, batched-model)
+      // Handle tile-based sources (vector, raster, raster-dem, batched-model,
+      // raster-array). `raster-array` is used by Mapbox Standard for layers
+      // like `mapbox-landmarks` (mapbox.mapbox-landmark-icons-v1) — the tiles
+      // are fetched from the same /v4/ endpoint as other tilesets, so the
+      // TileJSON resolution path below handles them uniformly.
       if (
         config.type === 'vector' ||
         config.type === 'raster' ||
         config.type === 'raster-dem' ||
+        config.type === 'raster-array' ||
         config.type === 'batched-model'
       ) {
         // Handle direct tile URLs in the source config

--- a/src/storage/indexedDbManager.ts
+++ b/src/storage/indexedDbManager.ts
@@ -45,7 +45,7 @@ export async function resetOfflineMapDB(): Promise<void> {
  * Called during initial database creation or when stores are missing.
  */
 function createStores(db: IDBPDatabase<OfflineMapDB>): void {
-  const stores = ['regions', 'tiles', 'styles', 'sprites', 'glyphs', 'fonts'] as const;
+  const stores = ['regions', 'tiles', 'styles', 'sprites', 'glyphs', 'fonts', 'models'] as const;
 
   for (const storeName of stores) {
     if (!db.objectStoreNames.contains(storeName)) {
@@ -138,6 +138,7 @@ function migrateRegionsToStyles(transaction: IDBTransaction): void {
  * - sprites: Sprite images and JSON
  * - glyphs: Font glyph data
  * - fonts: Font files
+ * - models: 3D model files (.glb) for Mapbox Standard tree/turbine layers
  * - regions: (deprecated) Legacy region storage, migrated to styles.regions[]
  *
  * @example
@@ -158,6 +159,9 @@ async function openOfflineMapDB(): Promise<IDBPDatabase<OfflineMapDB>> {
         if (oldVersion > 0 && oldVersion < 3) {
           migrateRegionsToStyles(transaction as unknown as IDBTransaction);
         }
+        // Migration: v3 -> v4
+        // Adds the `models` store for Mapbox Standard 3D model assets.
+        // No data migration needed — createStores above handles it.
       },
     });
   } catch (error) {

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -5,6 +5,7 @@ import type { FontEntry } from './font';
 import type { TileEntry } from './tile';
 import type { SpriteEntry } from './sprite';
 import type { GlyphEntry } from './glyph';
+import type { ModelEntry } from './model';
 
 export interface OfflineMapDB extends DBSchema {
   /**
@@ -35,5 +36,13 @@ export interface OfflineMapDB extends DBSchema {
   fonts: {
     key: string;
     value: FontEntry;
+  };
+  /**
+   * 3D model files (.glb) referenced by `style.models` entries. Used by
+   * Mapbox Standard for tree / wind-turbine model layers.
+   */
+  models: {
+    key: string;
+    value: ModelEntry;
   };
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,6 +5,7 @@ export * from './font';
 export * from './tile';
 export * from './sprite';
 export * from './glyph';
+export * from './model';
 export * from './database';
 export * from './maintenance';
 export * from './progress';

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -1,0 +1,59 @@
+import { DownloadProgress } from './progress';
+
+/**
+ * 3D model asset (e.g. a tree or turbine .glb) stored in IndexedDB.
+ *
+ * Mapbox Standard references 32 models via the top-level `style.models`
+ * dictionary (`{ "maple1-lod1": "mapbox://models/mapbox/maple1-v4-lod1.glb" }`).
+ * Layers of type `model` then pick one by name at render time.
+ */
+export interface ModelEntry {
+  /** Storage key: `{styleId}::model::{modelName}`. */
+  key: string;
+  /** Model binary (.glb / .gltf) as ArrayBuffer. */
+  data: ArrayBuffer;
+  /** HTTP Content-Type (usually `model/gltf-binary`). */
+  contentType: string;
+  /** Byte length. */
+  size: number;
+  /** URL the model was downloaded from. */
+  url: string;
+  /** Style this model belongs to. */
+  styleId: string;
+  /** Model name (the key in `style.models`). */
+  modelName: string;
+  /** Last-Modified or download timestamp (ms since epoch). */
+  lastModified: number;
+  /** ISO 8601 download timestamp. */
+  downloadedAt: string;
+  /** Optional expiry from HTTP Cache-Control. */
+  expires?: number;
+}
+
+/** Options for `downloadModels`. */
+export interface ModelDownloadOptions {
+  onProgress?: (progress: DownloadProgress) => void;
+  batchSize?: number;
+  maxRetries?: number;
+  skipExisting?: boolean;
+  timeoutMs?: number;
+}
+
+/** Result of a model download batch. */
+export interface ModelDownloadResult {
+  totalModels: number;
+  downloadedModels: number;
+  skippedModels: number;
+  failedModels: number;
+  totalSize: number;
+  errors: Array<{ url: string; error: string }>;
+}
+
+/** Aggregate stats across stored models. */
+export interface EnhancedModelStats {
+  count: number;
+  totalSize: number;
+  averageSize: number;
+  models: Array<{ name: string; size: number; lastModified?: number }>;
+  modelsByStyle: Record<string, number>;
+}

--- a/src/types/region.ts
+++ b/src/types/region.ts
@@ -2,12 +2,13 @@ import type { StyleProvider } from './style';
 import type { TileDownloadOptions, TileDownloadResult } from './tile';
 import type { SpriteDownloadResult } from './sprite';
 import type { GlyphDownloadResult } from './glyph';
+import type { ModelDownloadResult } from './model';
 import type { StyleDownloadResult } from './style';
 
 /**
  * Phase of a region download pipeline, reported via `DownloadRegionOptions.onProgress`.
  */
-export type DownloadRegionPhase = 'style' | 'sprites' | 'glyphs' | 'tiles' | 'metadata';
+export type DownloadRegionPhase = 'style' | 'sprites' | 'glyphs' | 'models' | 'tiles' | 'metadata';
 
 /**
  * Progress update emitted by `OfflineMapManager.downloadRegion`.
@@ -34,6 +35,14 @@ export interface DownloadRegionOptions {
   skipGlyphs?: boolean;
   /** Skip sprite download entirely. Default: false. */
   skipSprites?: boolean;
+  /**
+   * Skip 3D model download. Default: false. Models (e.g. Mapbox Standard
+   * trees / wind turbines) are declared via `style.models` and live at
+   * `mapbox://models/…` URLs that only Mapbox serves. Skip for styles that
+   * don't use model layers, or to reduce storage footprint at the cost of
+   * missing tree/turbine rendering.
+   */
+  skipModels?: boolean;
   /** Override Unicode glyph ranges fetched per font. Defaults to `GLYPH_CONFIG.COMPREHENSIVE_RANGES`. */
   glyphRanges?: string[];
   /** Extra options forwarded to the tile download step. */
@@ -49,6 +58,7 @@ export interface DownloadRegionResult {
   styleResult?: StyleDownloadResult;
   spriteResults: SpriteDownloadResult[];
   glyphResult?: GlyphDownloadResult;
+  modelResult?: ModelDownloadResult;
   tileResult: TileDownloadResult;
 }
 

--- a/src/types/style.ts
+++ b/src/types/style.ts
@@ -20,7 +20,16 @@ export interface BaseStyle {
     data?: BaseStyle;
     config?: Record<string, unknown>;
   }>;
-  models?: Record<string, { uri: string; [key: string]: unknown }>;
+  /**
+   * 3D model declarations used by `model` layers (Mapbox Standard trees /
+   * wind turbines). Two shapes are accepted in the wild:
+   *
+   * - Mapbox Standard format — values are plain URI strings:
+   *   `{ "maple1-lod1": "mapbox://models/mapbox/maple1-v4-lod1.glb" }`
+   * - Older / generic format — values wrap the URI in an object:
+   *   `{ "name": { "uri": "mapbox://..." } }`
+   */
+  models?: Record<string, string | { uri?: string; [key: string]: unknown }>;
   [key: string]: unknown;
 }
 

--- a/src/ui/managers/PanelManager.ts
+++ b/src/ui/managers/PanelManager.ts
@@ -1385,11 +1385,13 @@ export class PanelRenderer extends BaseComponent {
             }
           }
 
-          // Apply maxzoom to all tile sources (including batched-model for 3D buildings)
+          // Apply maxzoom to all tile sources (including batched-model for 3D
+          // buildings and raster-array for Mapbox Standard landmark icons).
           if (
             src.type === 'vector' ||
             src.type === 'raster' ||
             src.type === 'raster-dem' ||
+            src.type === 'raster-array' ||
             src.type === 'batched-model'
           ) {
             const originalMaxzoom = src.maxzoom as number | undefined;

--- a/src/ui/managers/downloadManager.ts
+++ b/src/ui/managers/downloadManager.ts
@@ -79,7 +79,7 @@ export interface DownloadProgress {
   /** Human-readable description of current activity */
   currentResource: string;
   /** Current download phase */
-  phase?: 'style' | 'sprites' | 'glyphs' | 'tiles';
+  phase?: 'style' | 'sprites' | 'glyphs' | 'models' | 'tiles';
 }
 
 /**

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -5,7 +5,7 @@
 
 // IndexedDB Configuration
 export const DB_NAME = 'offline-map-db';
-export const DB_VERSION = 3;
+export const DB_VERSION = 4;
 
 // Store Names (regions are stored inside styles.regions[], not as a separate store)
 export const STORE_NAMES = {
@@ -14,6 +14,7 @@ export const STORE_NAMES = {
   SPRITES: 'sprites',
   GLYPHS: 'glyphs',
   FONTS: 'fonts',
+  MODELS: 'models',
 } as const;
 
 // Download Configuration

--- a/src/utils/convertStyleForSW.ts
+++ b/src/utils/convertStyleForSW.ts
@@ -60,12 +60,21 @@ export function convertStyleForServiceWorker(style: MapboxStyle): MapboxStyle {
     }
   }
 
-  // Convert models
+  // Convert models. Two shapes in the wild:
+  //   - Mapbox Standard: `{ name: "idb://..." }` (string value)
+  //   - Older/generic:   `{ name: { uri: "idb://..." } }` (object value)
   if (converted.models) {
-    for (const modelKey of Object.keys(converted.models)) {
-      const model = converted.models[modelKey];
-      if (model.uri && typeof model.uri === 'string' && model.uri.startsWith('idb://')) {
-        model.uri = replace(model.uri);
+    const models = converted.models as Record<string, string | { uri?: string }>;
+    for (const modelKey of Object.keys(models)) {
+      const value = models[modelKey];
+      if (typeof value === 'string') {
+        if (value.startsWith('idb://')) {
+          models[modelKey] = replace(value);
+        }
+      } else if (value && typeof value === 'object') {
+        if (typeof value.uri === 'string' && value.uri.startsWith('idb://')) {
+          value.uri = replace(value.uri);
+        }
       }
     }
   }

--- a/src/utils/idbFetchHandler.ts
+++ b/src/utils/idbFetchHandler.ts
@@ -12,6 +12,7 @@ const idbLogger = logger.scope('IDBFetch');
 // idb://{downloadId}/tile/{sourceKey}/{url}
 // idb://{downloadId}/glyph/{fontstack}/{range}.pbf
 // idb://{downloadId}/sprite/{spriteName}
+// idb://{styleId}/model/{modelName}
 // idb://{downloadId}/tilesjson/{url}
 
 // Cache for region ID to style mapping to avoid repeated DB queries
@@ -482,6 +483,35 @@ export async function idbFetchHandler(url: string, init?: RequestInit): Promise<
         } else {
           idbLogger.warn(`Font not found: ${key}`);
         }
+        break;
+      }
+      case 'model': {
+        // Model URLs are rewritten by patchStyleForOffline to:
+        //   idb://{styleId}/model/{modelName}
+        // Models are keyed by {styleId}::model::{modelName} in the store.
+        // Mirror the sprite resolution fallback: try the style ID first,
+        // then the download/region ID (in case the request came through a
+        // region-scoped URL).
+        const styleEntry = await findStyleByRegionId(db, downloadId);
+        const actualStyleId = styleEntry?.key || downloadId;
+        const candidates = Array.from(
+          new Set([
+            `${actualStyleId}::model::${decodedResourcePath}`,
+            `${downloadId}::model::${decodedResourcePath}`,
+          ])
+        );
+        idbLogger.debug(`Model candidates for "${decodedResourcePath}":`, candidates);
+        for (const candidateKey of candidates) {
+          const resource = await db.get('models', candidateKey);
+          if (resource?.data) {
+            idbLogger.debug(`Found model using key: ${candidateKey}`);
+            return new Response(resource.data, {
+              status: 200,
+              headers: { 'Content-Type': resource.contentType || 'model/gltf-binary' },
+            });
+          }
+        }
+        idbLogger.warn(`Model not found, tried keys: ${candidates.join(', ')}`);
         break;
       }
       case 'tilesjson': {

--- a/src/utils/styleUtils.ts
+++ b/src/utils/styleUtils.ts
@@ -125,14 +125,28 @@ export function patchStyleForOffline(
     }
   }
 
-  // Patch top-level models (Mapbox Standard 3D landmarks)
+  // Patch top-level models (Mapbox Standard 3D trees / wind turbines).
+  // Two shapes exist in the wild:
+  //   - Mapbox Standard: `{ "maple1-lod1": "mapbox://models/mapbox/maple1-v4-lod1.glb" }` (string values)
+  //   - Older/generic:   `{ "name": { "uri": "mapbox://..." } }`               (object values)
+  // Models are keyed on the style ID (like sprites) so they can be shared
+  // across regions.
   if (style.models) {
-    for (const [modelId, modelConfig] of Object.entries(style.models)) {
-      if (modelConfig.uri) {
-        modelConfig.uri = `idb://${downloadId}/model/${modelId}`;
+    const modelBaseId = styleId || downloadId;
+    const models = style.models as unknown as Record<string, string | { uri?: string }>;
+    let patchedCount = 0;
+    for (const [modelId, value] of Object.entries(models)) {
+      if (typeof value === 'string') {
+        models[modelId] = `idb://${modelBaseId}/model/${modelId}`;
+        patchedCount++;
+      } else if (value && typeof value === 'object' && 'uri' in value && value.uri) {
+        value.uri = `idb://${modelBaseId}/model/${modelId}`;
+        patchedCount++;
       }
     }
-    styleLogger.debug(`Patched ${Object.keys(style.models).length} model URIs`);
+    if (patchedCount > 0) {
+      styleLogger.debug(`Patched ${patchedCount} model URIs (styleId: ${modelBaseId})`);
+    }
   }
 
   styleLogger.debug(`Final patched style:`, style);

--- a/tests/services/modelService.test.ts
+++ b/tests/services/modelService.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Tests for Model Service
+ */
+import { ModelService, modelKeyBelongsToStyle } from '../../src/services/modelService';
+import { dbPromise } from '../../src/storage/indexedDbManager';
+
+// Mock fetchResourceWithRetry so tests don't hit the network.
+const mockFetch = jest.fn();
+jest.mock('../../src/utils/download', () => {
+  const actual = jest.requireActual('../../src/utils/download');
+  return {
+    ...actual,
+    fetchResourceWithRetry: (...args: unknown[]) => mockFetch(...args),
+  };
+});
+
+describe('ModelService', () => {
+  let service: ModelService;
+
+  beforeEach(async () => {
+    service = new ModelService();
+    mockFetch.mockReset();
+    const db = await dbPromise;
+    await db.clear('models');
+  });
+
+  describe('modelKeyBelongsToStyle', () => {
+    it('matches keys prefixed by the style id and ::model::', () => {
+      expect(modelKeyBelongsToStyle('style-abc::model::tree-lod1', 'style-abc')).toBe(true);
+    });
+    it('does not match a different styleId', () => {
+      expect(modelKeyBelongsToStyle('style-xyz::model::foo', 'style-abc')).toBe(false);
+    });
+    it('does not match keys without the ::model:: marker', () => {
+      expect(modelKeyBelongsToStyle('style-abc::tree-lod1', 'style-abc')).toBe(false);
+    });
+  });
+
+  describe('downloadModels', () => {
+    it('stores each model under {styleId}::model::{name}', async () => {
+      mockFetch.mockResolvedValue({
+        type: 'image',
+        data: new ArrayBuffer(16),
+        contentType: 'model/gltf-binary',
+      });
+      const models = {
+        'maple1-lod1': 'https://api.mapbox.com/models/v1/mapbox/maple1-v4-lod1.glb',
+        'oak1-lod2': 'https://api.mapbox.com/models/v1/mapbox/oak1-v4-lod2.glb',
+      };
+      const result = await service.downloadModels(models, 'style-abc');
+
+      expect(result.totalModels).toBe(2);
+      expect(result.downloadedModels).toBe(2);
+      expect(result.failedModels).toBe(0);
+      expect(result.totalSize).toBe(32);
+
+      const db = await dbPromise;
+      const first = await db.get('models', 'style-abc::model::maple1-lod1');
+      expect(first?.modelName).toBe('maple1-lod1');
+      expect(first?.styleId).toBe('style-abc');
+      expect(first?.size).toBe(16);
+    });
+
+    it('skips models already in store when skipExisting is true (default)', async () => {
+      const db = await dbPromise;
+      await db.put('models', {
+        key: 'style-abc::model::existing',
+        data: new ArrayBuffer(4),
+        contentType: 'model/gltf-binary',
+        size: 4,
+        url: 'https://example.com/existing.glb',
+        styleId: 'style-abc',
+        modelName: 'existing',
+        lastModified: Date.now(),
+        downloadedAt: new Date().toISOString(),
+      });
+
+      mockFetch.mockResolvedValue({
+        type: 'image',
+        data: new ArrayBuffer(16),
+        contentType: 'model/gltf-binary',
+      });
+      const result = await service.downloadModels(
+        {
+          existing: 'https://example.com/existing.glb',
+          'new-one': 'https://example.com/new.glb',
+        },
+        'style-abc'
+      );
+
+      expect(result.skippedModels).toBe(1);
+      expect(result.downloadedModels).toBe(1);
+      // Only one fetch fired — for the new model.
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('records failures without aborting the whole batch', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          type: 'image',
+          data: new ArrayBuffer(8),
+          contentType: 'model/gltf-binary',
+        })
+        .mockRejectedValueOnce(new Error('network'));
+
+      const result = await service.downloadModels(
+        {
+          good: 'https://example.com/good.glb',
+          bad: 'https://example.com/bad.glb',
+        },
+        'style-abc'
+      );
+
+      expect(result.downloadedModels).toBe(1);
+      expect(result.failedModels).toBe(1);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].url).toBe('https://example.com/bad.glb');
+    });
+
+    it('returns an empty result when given no models', async () => {
+      const result = await service.downloadModels({}, 'style-abc');
+      expect(result.totalModels).toBe(0);
+      expect(result.downloadedModels).toBe(0);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getModelStats', () => {
+    it('aggregates count, size, and per-style breakdown', async () => {
+      const db = await dbPromise;
+      const now = Date.now();
+      const base = { contentType: 'model/gltf-binary', url: '', downloadedAt: '' };
+      await db.put('models', {
+        key: 'a::model::m1',
+        data: new ArrayBuffer(10),
+        size: 10,
+        styleId: 'a',
+        modelName: 'm1',
+        lastModified: now,
+        ...base,
+      });
+      await db.put('models', {
+        key: 'a::model::m2',
+        data: new ArrayBuffer(30),
+        size: 30,
+        styleId: 'a',
+        modelName: 'm2',
+        lastModified: now,
+        ...base,
+      });
+      await db.put('models', {
+        key: 'b::model::m1',
+        data: new ArrayBuffer(20),
+        size: 20,
+        styleId: 'b',
+        modelName: 'm1',
+        lastModified: now,
+        ...base,
+      });
+
+      const stats = await service.getModelStats();
+      expect(stats.count).toBe(3);
+      expect(stats.totalSize).toBe(60);
+      expect(stats.averageSize).toBe(20);
+      expect(stats.modelsByStyle).toEqual({ a: 2, b: 1 });
+    });
+  });
+
+  describe('cleanupOldModels', () => {
+    it('deletes models older than maxAge days', async () => {
+      const db = await dbPromise;
+      const fortyDaysAgo = Date.now() - 40 * 24 * 60 * 60 * 1000;
+      await db.put('models', {
+        key: 'a::model::old',
+        data: new ArrayBuffer(1),
+        size: 1,
+        styleId: 'a',
+        modelName: 'old',
+        lastModified: fortyDaysAgo,
+        contentType: '',
+        url: '',
+        downloadedAt: '',
+      });
+      await db.put('models', {
+        key: 'a::model::fresh',
+        data: new ArrayBuffer(1),
+        size: 1,
+        styleId: 'a',
+        modelName: 'fresh',
+        lastModified: Date.now(),
+        contentType: '',
+        url: '',
+        downloadedAt: '',
+      });
+      const deleted = await service.cleanupOldModels(30);
+      expect(deleted).toBe(1);
+      expect(await db.get('models', 'a::model::old')).toBeUndefined();
+      expect(await db.get('models', 'a::model::fresh')).toBeDefined();
+    });
+  });
+
+  describe('verifyAndRepairModels', () => {
+    it('removes entries with empty data', async () => {
+      const db = await dbPromise;
+      await db.put('models', {
+        key: 'a::model::good',
+        data: new ArrayBuffer(8),
+        size: 8,
+        styleId: 'a',
+        modelName: 'good',
+        lastModified: Date.now(),
+        contentType: '',
+        url: '',
+        downloadedAt: '',
+      });
+      await db.put('models', {
+        key: 'a::model::empty',
+        data: new ArrayBuffer(0),
+        size: 0,
+        styleId: 'a',
+        modelName: 'empty',
+        lastModified: Date.now(),
+        contentType: '',
+        url: '',
+        downloadedAt: '',
+      });
+      const result = await service.verifyAndRepairModels();
+      expect(result.verified).toBe(1);
+      expect(result.removed).toBe(1);
+    });
+  });
+});

--- a/tests/services/regionService.test.ts
+++ b/tests/services/regionService.test.ts
@@ -887,5 +887,38 @@ describe('RegionService', () => {
       await regionService.loadRegion(makeRegion());
       expect(mockDownloadTiles).toHaveBeenCalledTimes(1);
     });
+
+    it('fetches iconset.pbf alongside sprite for Mapbox Standard styles', async () => {
+      // Mapbox Standard serves an iconset.pbf sibling under the same
+      // /styles/v1/.../<hash>/ path as the sprite.json/png. Our sprite
+      // download must include it in the URL list for that family.
+      await seedStyle({
+        originalSpriteUrl:
+          'https://api.mapbox.com/styles/v1/mapbox/standard/abc123/sprite?access_token=pk.foo',
+      });
+      await regionService.downloadRegion(makeRegion());
+      expect(mockDownloadSprites).toHaveBeenCalledTimes(1);
+      const spriteUrls = mockDownloadSprites.mock.calls[0][0] as string[];
+      // Base four variants still fetched
+      expect(spriteUrls.some(u => u.includes('/sprite.json'))).toBe(true);
+      expect(spriteUrls.some(u => u.includes('/sprite.png'))).toBe(true);
+      expect(spriteUrls.some(u => u.includes('/sprite@2x.json'))).toBe(true);
+      expect(spriteUrls.some(u => u.includes('/sprite@2x.png'))).toBe(true);
+      // Plus the new iconset.pbf sibling
+      expect(spriteUrls.some(u => u.includes('/iconset.pbf'))).toBe(true);
+    });
+
+    it('does NOT fetch iconset.pbf for non-Mapbox sprite URLs', async () => {
+      // OpenFreeMap and other providers don't have iconset.pbf — we must
+      // not synthesize a bogus URL that would 404.
+      await seedStyle({
+        originalSpriteUrl: 'https://tiles.openfreemap.org/sprites/ofm_f384/ofm',
+      });
+      await regionService.downloadRegion(makeRegion());
+      const spriteUrls = mockDownloadSprites.mock.calls[0][0] as string[];
+      expect(spriteUrls.some(u => u.includes('iconset.pbf'))).toBe(false);
+      // Base four variants still present
+      expect(spriteUrls).toHaveLength(4);
+    });
   });
 });

--- a/tests/services/regionService.test.ts
+++ b/tests/services/regionService.test.ts
@@ -4,6 +4,7 @@
 const mockDownloadTiles = jest.fn();
 const mockDownloadSprites = jest.fn();
 const mockDownloadGlyphs = jest.fn();
+const mockDownloadModels = jest.fn();
 const mockDownloadStyleWithProvider = jest.fn();
 
 jest.mock('../../src/services/tileService', () => {
@@ -27,6 +28,14 @@ jest.mock('../../src/services/glyphService', () => {
   return {
     ...actual,
     downloadGlyphs: (...args: unknown[]) => mockDownloadGlyphs(...args),
+  };
+});
+
+jest.mock('../../src/services/modelService', () => {
+  const actual = jest.requireActual('../../src/services/modelService');
+  return {
+    ...actual,
+    downloadModels: (...args: unknown[]) => mockDownloadModels(...args),
   };
 });
 
@@ -69,6 +78,7 @@ describe('RegionService', () => {
     mockDownloadTiles.mockReset();
     mockDownloadSprites.mockReset();
     mockDownloadGlyphs.mockReset();
+    mockDownloadModels.mockReset();
     mockDownloadStyleWithProvider.mockReset();
 
     mockDownloadTiles.mockResolvedValue({
@@ -83,6 +93,14 @@ describe('RegionService', () => {
       tileExtension: 'pbf',
     });
     mockDownloadSprites.mockResolvedValue({ downloaded: 0, failed: 0 });
+    mockDownloadModels.mockResolvedValue({
+      totalModels: 0,
+      downloadedModels: 0,
+      skippedModels: 0,
+      failedModels: 0,
+      totalSize: 0,
+      errors: [],
+    });
     // Simulate the real glyphService.downloadGlyphs which fires onProgress
     // at least once (the orchestrator relies on this to surface the `glyphs`
     // phase now that we no longer pre-emit a synthetic progress event).
@@ -906,6 +924,68 @@ describe('RegionService', () => {
       expect(spriteUrls.some(u => u.includes('/sprite@2x.png'))).toBe(true);
       // Plus the new iconset.pbf sibling
       expect(spriteUrls.some(u => u.includes('/iconset.pbf'))).toBe(true);
+    });
+
+    it('downloads style.models during the models phase (Mapbox Standard trees/turbines)', async () => {
+      await seedStyle({
+        style: {
+          version: 8,
+          sources: { v: { tiles: ['http://tiles/{z}/{x}/{y}.pbf'] } },
+          layers: [],
+          sprite: 'https://example.com/sprites/sprite',
+          glyphs: 'https://example.com/fonts/{fontstack}/{range}.pbf',
+          // Mapbox Standard-style model shape: {name: "URI string"}.
+          models: {
+            'maple1-lod1': 'https://api.mapbox.com/models/v1/mapbox/maple1-v4-lod1.glb?access_token=foo',
+            'oak1-lod2': 'https://api.mapbox.com/models/v1/mapbox/oak1-v4-lod2.glb?access_token=foo',
+          },
+        },
+      });
+      const phases: string[] = [];
+      await regionService.downloadRegion(makeRegion(), {
+        onProgress: p => {
+          if (!phases.includes(p.phase)) phases.push(p.phase);
+        },
+      });
+      expect(mockDownloadModels).toHaveBeenCalledTimes(1);
+      const [resolved, styleIdArg] = mockDownloadModels.mock.calls[0];
+      expect(Object.keys(resolved)).toEqual(['maple1-lod1', 'oak1-lod2']);
+      expect(styleIdArg).toBe('test-style-id');
+      expect(phases).toContain('models');
+    });
+
+    it('skips the models phase entirely when skipModels: true', async () => {
+      await seedStyle({
+        style: {
+          version: 8,
+          sources: { v: { tiles: ['http://tiles/{z}/{x}/{y}.pbf'] } },
+          layers: [],
+          models: { 'tree-lod1': 'https://api.mapbox.com/models/v1/mapbox/oak1-v4-lod1.glb' },
+        },
+      });
+      await regionService.downloadRegion(makeRegion(), { skipModels: true });
+      expect(mockDownloadModels).not.toHaveBeenCalled();
+    });
+
+    it('does NOT re-download models that were already patched to idb://', async () => {
+      // Once a region has been downloaded, patchStyleForOffline rewrites
+      // style.models URIs to idb://... — those should be no-ops on a
+      // subsequent download, not generate bogus fetches.
+      await seedStyle({
+        style: {
+          version: 8,
+          sources: { v: { tiles: ['http://tiles/{z}/{x}/{y}.pbf'] } },
+          layers: [],
+          models: {
+            'already-patched': 'idb://test-style-id/model/already-patched',
+            'fresh-model': 'https://api.mapbox.com/models/v1/mapbox/maple1-v4-lod1.glb',
+          },
+        },
+      });
+      await regionService.downloadRegion(makeRegion());
+      const [resolved] = mockDownloadModels.mock.calls[0];
+      expect(Object.keys(resolved)).toEqual(['fresh-model']);
+      expect(resolved['already-patched']).toBeUndefined();
     });
 
     it('does NOT fetch iconset.pbf for non-Mapbox sprite URLs', async () => {

--- a/tests/services/tileService.test.ts
+++ b/tests/services/tileService.test.ts
@@ -664,6 +664,44 @@ describe('TileService', () => {
         global.fetch = realFetch;
       }
     });
+
+    it('accepts raster-array sources (Mapbox Standard landmark-icons)', async () => {
+      // `raster-array` is used by Mapbox Standard's `mapbox-landmarks` source.
+      // Previously filtered out of the plan; this regression guards the fix.
+      const realFetch = global.fetch;
+      const mockFetch = jest.fn().mockResolvedValue(new Response(new ArrayBuffer(0), { status: 200 }));
+      global.fetch = mockFetch as unknown as typeof fetch;
+
+      const region = {
+        id: 'test-raster-array',
+        name: 'Raster array',
+        bounds: [[55.27, 25.2], [55.4, 25.34]] as [[number, number], [number, number]],
+        minZoom: 10,
+        maxZoom: 10,
+      };
+      const style = {
+        version: 8 as const,
+        sources: {
+          'mapbox-landmarks': {
+            type: 'raster-array',
+            tiles: [
+              'https://a.tiles.mapbox.com/v4/mapbox.mapbox-landmark-icons-v1/{z}/{x}/{y}.raster',
+            ],
+          },
+        },
+        layers: [],
+      };
+      try {
+        const result = await service.downloadTiles(region, style, 'test-raster-array-style', {
+          probeSourcesBeforeDownload: false,
+          storageQuotaCheck: false,
+          maxRetries: 0,
+        });
+        expect(result.totalTiles).toBeGreaterThan(0);
+      } finally {
+        global.fetch = realFetch;
+      }
+    });
   });
 
   describe('exported functions', () => {

--- a/tests/utils/constants.test.ts
+++ b/tests/utils/constants.test.ts
@@ -30,8 +30,8 @@ describe('constants', () => {
       expect(DB_NAME).toBe('offline-map-db');
     });
 
-    it('should have DB_VERSION set to 3', () => {
-      expect(DB_VERSION).toBe(3);
+    it('should have DB_VERSION set to 4', () => {
+      expect(DB_VERSION).toBe(4);
     });
   });
 
@@ -56,8 +56,12 @@ describe('constants', () => {
       expect(STORE_NAMES.FONTS).toBe('fonts');
     });
 
-    it('should have exactly 5 stores', () => {
-      expect(Object.keys(STORE_NAMES)).toHaveLength(5);
+    it('should define the models store', () => {
+      expect(STORE_NAMES.MODELS).toBe('models');
+    });
+
+    it('should have exactly 6 stores', () => {
+      expect(Object.keys(STORE_NAMES)).toHaveLength(6);
     });
   });
 

--- a/tests/utils/styleUtils.test.ts
+++ b/tests/utils/styleUtils.test.ts
@@ -301,6 +301,47 @@ describe('styleUtils', () => {
       expect(patched.sprite).toBe('idb://region-1/sprite/sprite');
     });
 
+    it('patches string-valued models to idb:// URLs (Mapbox Standard shape)', () => {
+      const style: MapboxStyle = {
+        version: 8,
+        sources: {},
+        layers: [],
+        models: {
+          'maple1-lod1': 'mapbox://models/mapbox/maple1-v4-lod1.glb',
+          'oak1-lod2': 'mapbox://models/mapbox/oak1-v4-lod2.glb',
+        },
+      };
+      const patched = patchStyleForOffline(style, 'region-1', undefined, undefined, 'style-xyz');
+      expect(patched.models?.['maple1-lod1']).toBe('idb://style-xyz/model/maple1-lod1');
+      expect(patched.models?.['oak1-lod2']).toBe('idb://style-xyz/model/oak1-lod2');
+    });
+
+    it('patches object-valued models (older/generic {uri} shape)', () => {
+      const style: MapboxStyle = {
+        version: 8,
+        sources: {},
+        layers: [],
+        models: {
+          'some-model': { uri: 'https://example.com/some.glb', extra: 'kept' },
+        },
+      };
+      const patched = patchStyleForOffline(style, 'region-1', undefined, undefined, 'style-xyz');
+      const m = patched.models?.['some-model'] as { uri: string; extra: string };
+      expect(m.uri).toBe('idb://style-xyz/model/some-model');
+      expect(m.extra).toBe('kept'); // non-uri props preserved
+    });
+
+    it('keys models off downloadId when styleId is not provided', () => {
+      const style: MapboxStyle = {
+        version: 8,
+        sources: {},
+        layers: [],
+        models: { 'tree-lod1': 'mapbox://models/mapbox/oak1-v4-lod1.glb' },
+      };
+      const patched = patchStyleForOffline(style, 'region-abc');
+      expect(patched.models?.['tree-lod1']).toBe('idb://region-abc/model/tree-lod1');
+    });
+
     it('should default to pbf when tile URL has no recognizable extension', () => {
       const style: MapboxStyle = {
         version: 8,


### PR DESCRIPTION
Downloaded the live Mapbox Standard style JSON from the API (251KB, 150 layers, 8 sources, 32 model entries) and audited every referenced resource against our offline pipeline. **Three gaps** remained between 0.6.0 and a complete Mapbox Standard offline render. This PR fixes all three.

## Inventory

| # | Resource (from live style) | 0.6.0 status |
|---|---|---|
| 1 | Style JSON | ✅ |
| 2 | Sprite JSON/PNG ×4 | ✅ |
| 3 | **iconset.pbf** (Mapbox Standard icon protobuf) | ❌ → **fixed** |
| 4 | Glyphs | ✅ |
| 5 | Composite basemap (vector tiles) | ✅ |
| 6 | 3D buildings (batched-model GLB) | ✅ |
| 7 | Indoor (vector, sparse) | ✅ probe-skipped |
| 8 | 3D events (batched-model) | ✅ |
| 9 | Terrain DEM (raster-dem) | ✅ |
| 10 | Landmark POIs (vector, sparse) | ✅ probe-skipped |
| 11 | **Landmark icons** (raster-array) | ❌ → **fixed** |
| 12 | Procedural buildings (vector) | ✅ |
| 13 | **32 3D models** (maple / oak / pine / palm / turbine .glb) | ❌ → **fixed** |

## 1. 3D model pipeline (the big one)

`style.models` in Mapbox Standard is a dict of 32 entries. Three layers (`trees`, `wind-turbine-towers`, `wind-turbine-rotors`) pick one by name at render time. Previously there was zero offline support — trees and turbines were invisible offline.

**Added:**
- \`src/types/model.ts\` — \`ModelEntry\`, options, result, stats types
- New \`models\` IndexedDB store; \`DB_VERSION\` bumped **3 → 4** (idempotent additive migration — no data needs moving)
- \`src/services/modelService.ts\` — download / get / stats / cleanup / verify
- New \`'models'\` phase in \`regionService.downloadRegion\` (skippable via \`skipModels\`). Resolves \`mapbox://\` with the access token, ignores already-patched \`idb://\` entries
- \`patchStyleForOffline\` rewrites \`style.models\` entries to \`idb://<styleId>/model/<name>\`. Accepts both Mapbox Standard's string-valued shape (\`{ "name": "mapbox://..." }\`) AND the older/generic \`{ "name": { "uri": "..." } }\` shape
- \`idbFetchHandler\` — new \`'model'\` case serves GLBs with \`Content-Type: model/gltf-binary\`
- \`convertStyleForSW\` extended to handle both model shapes for the Service Worker path
- \`ResourceService\` / \`ResourceManagement\` expose \`downloadModelsWithOptions\`, \`getModelStats\`, \`cleanupOldModels\`, \`verifyAndRepairModels\`
- \`deleteStyleResources\` also clears the models store for a style

## 2. raster-array source type

Mapbox Standard's \`mapbox-landmarks\` source is \`type: 'raster-array'\`. Previously filtered out of \`extractTileSources\`; now accepted. \`PanelManager\`'s maxzoom guard also extended.

## 3. iconset.pbf

Mapbox Standard serves a ~300KB protobuf icon file alongside the sprite: \`/styles/v1/<owner>/<style>/<hash>/iconset.pbf\`. Mapbox GL SDK v3 fetches it automatically — we now do the same in \`regionService.downloadRegion\` by detecting the Mapbox Standard sprite URL pattern and appending an \`iconset.pbf\` sibling. Non-Mapbox providers (OpenFreeMap, MapTiler) are unaffected.

## Tests

**+16 new, all green locally (1412/1412 unit tests pass).**

- \`modelService.test.ts\` — 10 tests (key helper, download, skipExisting, failure isolation, empty input, stats, cleanup-by-age, repair-empty-data)
- \`regionService.test.ts\` — models phase runs for Standard styles; \`skipModels\` skips it; already-patched \`idb://\` models are filtered out; iconset.pbf fetched only for Mapbox URLs
- \`styleUtils.test.ts\` — string-valued and object-valued models patched; downloadId fallback
- \`tileService.test.ts\` — raster-array source accepted
- \`constants.test.ts\` — DB_VERSION 4, 6 stores

## Breaking changes

**None.** All additions are backwards-compatible. DB migration v3→v4 just creates the new \`models\` store idempotently via the existing \`createStores()\` helper; no data migration needed.

## Semver

Minor bump: **0.7.0** (new public exports: \`modelService\`, \`ModelEntry\`, \`downloadModelsWithOptions\`, etc., plus a new \`'models'\` variant in \`DownloadRegionPhase\`).

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` — no new warnings
- [x] \`npm test\` — 1412/1412 unit tests pass (5 pre-existing e2e failures unrelated)
- [x] \`prettier --check\` clean