### PR TITLE
fix(security): resolve CodeQL ReDoS + URL substring alerts, bump serialize-javascript

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -15227,15 +15227,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
@@ -16222,12 +16213,12 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-handler": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -43,5 +43,8 @@
   },
   "engines": {
     "node": ">=20.0"
+  },
+  "overrides": {
+    "serialize-javascript": "^7.0.5"
   }
 }

--- a/src/services/regionService.ts
+++ b/src/services/regionService.ts
@@ -420,9 +420,16 @@ export class RegionService {
           // /styles/v1/{owner}/{style}/{hash}/iconset.pbf. The last path
           // segment is `sprite`, so replacing it with `iconset.pbf` works.
           const pathWithoutQuery = qIndex !== -1 ? spriteBase.slice(0, qIndex) : spriteBase;
-          const isMapboxStandardSprite = /api\.mapbox\.com\/styles\/v1\/.+\/sprite$/.test(
-            pathWithoutQuery
-          );
+          let isMapboxStandardSprite = false;
+          try {
+            const parsed = new URL(pathWithoutQuery);
+            isMapboxStandardSprite =
+              parsed.hostname === 'api.mapbox.com' &&
+              parsed.pathname.startsWith('/styles/v1/') &&
+              parsed.pathname.endsWith('/sprite');
+          } catch {
+            // Non-URL sprite base (e.g. relative); not a Mapbox Standard sprite.
+          }
           if (isMapboxStandardSprite) {
             // The path-rewrite suffix replaces the trailing `sprite` segment.
             suffixes.push('__ICONSET__');

--- a/src/ui/modals/regionFormModal.ts
+++ b/src/ui/modals/regionFormModal.ts
@@ -10,6 +10,7 @@ import { Button } from '@/ui/components/shared/Button';
 import { icons } from '@/utils/icons';
 import { logger } from '@/utils/logger';
 import { escapeHtml } from '@/utils/formatting';
+import { isMapboxHost } from '@/utils/styleProviderUtils';
 import { t, i18n } from '@/ui/translations';
 
 const formLogger = logger.scope('RegionFormModal');
@@ -425,11 +426,7 @@ export class RegionFormModal {
     const styleUrl = this.styleUrlInput?.value || '';
 
     // Simple detection logic
-    if (
-      styleUrl.startsWith('mapbox://') ||
-      styleUrl.includes('mapbox.com') ||
-      styleUrl.includes('api.mapbox.com')
-    ) {
+    if (styleUrl.startsWith('mapbox://') || isMapboxHost(styleUrl)) {
       if (this.providerSelect) this.providerSelect.value = 'mapbox';
       this.toggleAccessTokenVisibility(true);
     } else if (

--- a/src/ui/offlineManagerControl.ts
+++ b/src/ui/offlineManagerControl.ts
@@ -242,43 +242,45 @@ export class OfflineManagerControl implements IControl {
 
       // Development proxy for CORS issues (when running on localhost)
       if (location.hostname === 'localhost' || location.hostname === '127.0.0.1') {
+        let parsed: URL | null = null;
+        try {
+          parsed = new URL(url, location.origin);
+        } catch {
+          parsed = null;
+        }
+        const hostname = parsed?.hostname ?? '';
+        const pathAndQuery = parsed ? parsed.pathname + parsed.search : '';
         // Proxy Carto tile requests (tiles and TileJSON)
-        const isTileRequest = /\/\d+\/\d+\/\d+\.(pbf|mvt|png|jpg|jpeg|webp)/.test(url);
-        const isTileJsonRequest = url.includes('.json') && url.includes('basemaps.cartocdn.com');
+        const isTileRequest = /\/\d+\/\d+\/\d+\.(pbf|mvt|png|jpg|jpeg|webp)/.test(
+          parsed?.pathname ?? ''
+        );
+        const isTileJsonRequest =
+          (parsed?.pathname.endsWith('.json') ?? false) &&
+          (hostname === 'basemaps.cartocdn.com' || hostname.endsWith('.basemaps.cartocdn.com'));
 
-        if (isTileRequest && url.includes('tiles-a.basemaps.cartocdn.com')) {
-          const proxyUrl = url.replace('https://tiles-a.basemaps.cartocdn.com', '/tiles/carto-a');
-          return originalFetch(proxyUrl, init);
-        }
-        if (isTileRequest && url.includes('tiles-b.basemaps.cartocdn.com')) {
-          const proxyUrl = url.replace('https://tiles-b.basemaps.cartocdn.com', '/tiles/carto-b');
-          return originalFetch(proxyUrl, init);
-        }
-        if (isTileRequest && url.includes('tiles-c.basemaps.cartocdn.com')) {
-          const proxyUrl = url.replace('https://tiles-c.basemaps.cartocdn.com', '/tiles/carto-c');
-          return originalFetch(proxyUrl, init);
-        }
-        if (isTileRequest && url.includes('tiles-d.basemaps.cartocdn.com')) {
-          const proxyUrl = url.replace('https://tiles-d.basemaps.cartocdn.com', '/tiles/carto-d');
-          return originalFetch(proxyUrl, init);
+        const cartoSubdomainProxy: Record<string, string> = {
+          'tiles-a.basemaps.cartocdn.com': '/tiles/carto-a',
+          'tiles-b.basemaps.cartocdn.com': '/tiles/carto-b',
+          'tiles-c.basemaps.cartocdn.com': '/tiles/carto-c',
+          'tiles-d.basemaps.cartocdn.com': '/tiles/carto-d',
+        };
+        if (isTileRequest && cartoSubdomainProxy[hostname]) {
+          return originalFetch(cartoSubdomainProxy[hostname] + pathAndQuery, init);
         }
 
         // Proxy TileJSON requests from tiles.basemaps.cartocdn.com
-        if (isTileJsonRequest && url.includes('tiles.basemaps.cartocdn.com')) {
-          const proxyUrl = url.replace('https://tiles.basemaps.cartocdn.com', '/carto-api');
-          return originalFetch(proxyUrl, init);
+        if (isTileJsonRequest && hostname === 'tiles.basemaps.cartocdn.com') {
+          return originalFetch('/carto-api' + pathAndQuery, init);
         }
 
         // Fallback for old format (tiles without subdomain)
-        if (isTileRequest && url.includes('tiles.basemaps.cartocdn.com')) {
-          const proxyUrl = url.replace('https://tiles.basemaps.cartocdn.com', '/tiles/carto-a');
-          return originalFetch(proxyUrl, init);
+        if (isTileRequest && hostname === 'tiles.basemaps.cartocdn.com') {
+          return originalFetch('/tiles/carto-a' + pathAndQuery, init);
         }
 
         // Proxy OpenStreetMap tile requests
-        if (url.includes('tile.openstreetmap.org')) {
-          const proxyUrl = url.replace('https://tile.openstreetmap.org', '/tiles/osm');
-          return originalFetch(proxyUrl, init);
+        if (hostname === 'tile.openstreetmap.org') {
+          return originalFetch('/tiles/osm' + pathAndQuery, init);
         }
       }
 

--- a/src/utils/idbFetchHandler.ts
+++ b/src/utils/idbFetchHandler.ts
@@ -258,7 +258,7 @@ export async function idbFetchHandler(url: string, init?: RequestInit): Promise<
           // but tiles are stored with integer zoom levels, so floor the value
           const z = Math.floor(parseFloat(pathParts[pathParts.length - 3]));
           const sourceKey = pathParts.slice(0, pathParts.length - 3).join('/');
-          const yMatch = yExt.match(/(\d+)\.(\w+)/);
+          const yMatch = yExt.match(/^(\d+)\.(\w+)$/);
           if (yMatch) {
             const y = parseInt(yMatch[1]);
             const requestedExt = yMatch[2]; // Extension from URL (for logging only)

--- a/src/utils/styleProviderUtils.ts
+++ b/src/utils/styleProviderUtils.ts
@@ -14,6 +14,38 @@ export function isMapboxProtocol(url: string): boolean {
 }
 
 /**
+ * Parse a URL and return its hostname, or null if the URL is malformed.
+ * Accepts relative URLs when `base` is provided.
+ */
+export function getUrlHostname(url: string, base?: string): string | null {
+  try {
+    return new URL(url, base).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * True if `url`'s hostname equals `host` or is a subdomain of `host`.
+ * Uses URL parsing (not substring matching) to avoid false positives like
+ * `https://evil.com/?x=mapbox.com` matching `mapbox.com`.
+ */
+export function hostMatches(url: string, host: string, base?: string): boolean {
+  const hostname = getUrlHostname(url, base);
+  if (hostname === null) return false;
+  const target = host.toLowerCase();
+  return hostname === target || hostname.endsWith('.' + target);
+}
+
+/**
+ * True for any host under the mapbox.com domain (including api.mapbox.com,
+ * *.tiles.mapbox.com, etc.). Used by provider detection.
+ */
+export function isMapboxHost(url: string, base?: string): boolean {
+  return hostMatches(url, 'mapbox.com', base);
+}
+
+/**
  * Resolve a mapbox:// URL to its HTTPS API equivalent
  *
  * Supported patterns:
@@ -97,11 +129,7 @@ export function rewriteMapboxCdnTileUrl(tileUrl: string): string {
  */
 export function detectStyleProvider(styleUrl: string, style?: BaseStyle): StyleProvider {
   // Check URL patterns
-  if (
-    isMapboxProtocol(styleUrl) ||
-    styleUrl.includes('mapbox.com') ||
-    styleUrl.includes('api.mapbox.com')
-  ) {
+  if (isMapboxProtocol(styleUrl) || isMapboxHost(styleUrl)) {
     return 'mapbox';
   }
 
@@ -125,7 +153,7 @@ export function detectStyleProvider(styleUrl: string, style?: BaseStyle): StyleP
     const sources = style.sources || {};
     for (const [, sourceConfig] of Object.entries(sources)) {
       const source = sourceConfig as { url?: string };
-      if (source.url && (source.url.includes('mapbox.com') || isMapboxProtocol(source.url))) {
+      if (source.url && (isMapboxProtocol(source.url) || isMapboxHost(source.url))) {
         return 'mapbox';
       }
     }
@@ -230,7 +258,7 @@ export function processStyleSources(
         if (isMapboxProtocol(tileUrl) && accessToken) {
           return resolveMapboxUrl(tileUrl, accessToken);
         }
-        if (provider === 'mapbox' && accessToken && tileUrl.includes('mapbox.com')) {
+        if (provider === 'mapbox' && accessToken && isMapboxHost(tileUrl)) {
           return normalizeStyleUrl(tileUrl, accessToken);
         }
         return tileUrl;
@@ -247,7 +275,7 @@ export function processStyleSources(
     if (typeof processedStyle.sprite === 'string') {
       if (isMapboxProtocol(processedStyle.sprite)) {
         processedStyle.sprite = resolveMapboxUrl(processedStyle.sprite, accessToken);
-      } else if (provider === 'mapbox' && processedStyle.sprite.includes('mapbox.com')) {
+      } else if (provider === 'mapbox' && isMapboxHost(processedStyle.sprite)) {
         processedStyle.sprite = normalizeStyleUrl(processedStyle.sprite, accessToken);
       }
     } else if (Array.isArray(processedStyle.sprite)) {
@@ -258,7 +286,7 @@ export function processStyleSources(
         if (typeof entry.url === 'string') {
           if (isMapboxProtocol(entry.url)) {
             return { ...entry, url: resolveMapboxUrl(entry.url, accessToken) };
-          } else if (provider === 'mapbox' && entry.url.includes('mapbox.com')) {
+          } else if (provider === 'mapbox' && isMapboxHost(entry.url)) {
             return { ...entry, url: normalizeStyleUrl(entry.url, accessToken) };
           }
         }
@@ -271,7 +299,7 @@ export function processStyleSources(
   if (processedStyle.glyphs && typeof processedStyle.glyphs === 'string' && accessToken) {
     if (isMapboxProtocol(processedStyle.glyphs)) {
       processedStyle.glyphs = resolveMapboxUrl(processedStyle.glyphs, accessToken);
-    } else if (provider === 'mapbox' && processedStyle.glyphs.includes('mapbox.com')) {
+    } else if (provider === 'mapbox' && isMapboxHost(processedStyle.glyphs)) {
       processedStyle.glyphs = normalizeStyleUrl(processedStyle.glyphs, accessToken);
     }
   }
@@ -324,14 +352,19 @@ export function validateStyleForProvider(
     // Check for Mapbox-specific requirements
     const hasMapboxSources = Object.values(style.sources || {}).some((source: unknown) => {
       const s = source as { url?: string };
-      return s.url && s.url.includes('mapbox.com');
+      return !!s.url && isMapboxHost(s.url);
     });
 
     if (hasMapboxSources) {
       // Check if access token might be needed
       const hasAccessToken = Object.values(style.sources || {}).some((source: unknown) => {
         const s = source as { url?: string };
-        return s.url && s.url.includes('access_token');
+        if (!s.url) return false;
+        try {
+          return new URL(s.url).searchParams.has('access_token');
+        } catch {
+          return false;
+        }
       });
 
       if (!hasAccessToken) {

--- a/tests/ui/modals/regionFormModal.test.ts
+++ b/tests/ui/modals/regionFormModal.test.ts
@@ -100,14 +100,15 @@ describe('RegionFormModal', () => {
     });
 
     it('should have Style URL input with default value', () => {
-      const options = createOptions({ styleUrl: 'https://custom.style.com/style.json' });
+      const styleUrl = 'https://custom.style.com/style.json';
+      const options = createOptions({ styleUrl });
       const modal = new RegionFormModal(options);
       const element = modal.show();
 
       expect(element.textContent).toContain('Style URL');
       const inputs = element.querySelectorAll('input[type="text"]');
       const styleInput = Array.from(inputs).find(
-        (input) => (input as HTMLInputElement).value.includes('custom.style.com')
+        (input) => (input as HTMLInputElement).value === styleUrl
       );
       expect(styleInput).not.toBeNull();
     });


### PR DESCRIPTION
## Summary
Closes all open GitHub code-scanning and Dependabot alerts.

### CodeQL — ReDoS (`js/polynomial-redos`, 2 alerts)
- `src/services/regionService.ts:423` — replace `/api\.mapbox\.com\/styles\/v1\/.+\/sprite$/` with `new URL(...)` hostname + pathname check.
- `src/utils/idbFetchHandler.ts:261` — anchor `(\d+)\.(\w+)` with `^…$`.

### CodeQL — Incomplete URL substring sanitization (`js/incomplete-url-substring-sanitization`, 19 alerts)
- Add `getUrlHostname` / `hostMatches` / `isMapboxHost` helpers in `src/utils/styleProviderUtils.ts` (parse URL, compare hostname, allow subdomains).
- Replace every `url.includes('mapbox.com')` / `includes('api.mapbox.com')` in `styleProviderUtils.ts` and `ui/modals/regionFormModal.ts` with `isMapboxHost(url)`. Access-token presence check now uses `URL.searchParams.has('access_token')`.
- `ui/offlineManagerControl.ts` dev-proxy interceptor now parses the request URL once and dispatches on exact `hostname` (Carto CDN subdomains, OSM tiles). Proxy URLs are rebuilt from `URL.pathname + URL.search` instead of `url.replace(...)`.
- Updated `tests/ui/modals/regionFormModal.test.ts` to compare the style URL by exact equality instead of substring.

### Dependabot — serialize-javascript (2 alerts, high + moderate)
- Add `overrides` entry in `docs/package.json` forcing `serialize-javascript` to `^7.0.5`; regenerated `docs/package-lock.json`. Fixes RCE via `RegExp.flags` / `Date.prototype.toISOString` and CPU-DoS via crafted array-likes. `npm audit` reports 0 vulnerabilities in `docs/`.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — only pre-existing warning, no new issues
- [x] `npm test` for touched suites: `styleProviderUtils`, `idbFetchHandler`, `regionService`, `regionFormModal`, `offlineManagerControl` (all pass)
- [x] Pre-commit hooks (format + lint + typecheck + full Jest non-e2e) green
- [ ] After merge: CodeQL scan rerun reports 0 open alerts on default branch