### PR TITLE
fix(mapbox-standard): load offline + SW model handler + tile-extension fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - 2026-04-23
+
+> **Bug-fix release: Mapbox Standard offline rendering.** `setStyle()` of a downloaded Standard region used to hang forever with `"Style is not done loading"` because two indoor-only expressions (`is-active-floor`, `floor-level`) that Mapbox GL v3 evaluates against `map.indoor.activeFloors` at filter-compile time were left intact when the `imports` wrapper was stripped. Two smaller correctness issues were fixed in the same pass.
+
+### Fixed
+
+- **Mapbox Standard style failed to load offline.** `resolveImports` now rewrites `["is-active-floor"]` and `["is-active-floor", <id>]` → `false` and `["floor-level"]` → `0` before the flattened style is stored, so the filters validate without the `imports` parent context. Existing regions downloaded with 0.8.0 are also healed — `sanitizeIndoorExpressions()` runs at load time in both `PanelManager.handleLoadStyle` and `OfflineManagerControl.loadOfflineStyle`, so **re-downloading is not required**.
+- **Offline Service Worker was missing its `model` handler.** `public/idb-offline-sw.js` only handled `tile / glyph / sprite / tilesjson`, so any worker-scoped request for a Mapbox Standard 3D-model `.glb` (trees, wind turbines) 400'd. Main-thread fetches worked because `window.fetch` is intercepted by `idbFetchHandler`, but `new Worker(...).fetch(...)` paths and the native v3 model-loader path didn't. Added `handleModel` mirroring the sprite resolver — tries `{styleId}::model::{name}` first, then `{downloadId}::model::{name}`, returns `Content-Type: model/gltf-binary` (or the stored content-type).
+- **Tile-extension regex only captured the first dotted segment.** For Mapbox v4 URLs like `.../{z}/{x}/{y}.vector.pbf`, `patchStyleForOffline` produced `idb://.../{y}.vector` but `tileService.extractExtension` stored the key under `.pbf`. Every tile fetch missed the primary key and went through `idbFetchHandler`'s pbf/mvt/png/jpg/webp fallback loop before resolving. Both sites now share a single `extractTileExtensionFromUrl(url)` helper in `src/utils/tileKey.ts` that captures the last extension before `?`, `#`, or end. (Regions downloaded on 0.8.0 still work — they just keep taking the fallback-loop path until re-downloaded.)
+
+### Added
+
+- Exported `sanitizeIndoorExpressions(style)` from `@/utils/importResolver` — idempotent, safe to call on any style object.
+- Exported `extractTileExtensionFromUrl(url)` from `@/utils/tileKey` — single source of truth; `deriveTileExtension(tiles)` now delegates to it.
+
+### Tests
+
+- +15 tests: 6 for `sanitizeIndoorExpressions`, 4 for the SW `model` handler (missing / default content-type / stored content-type override / region-id resolution), 5 for `extractTileExtensionFromUrl` (single-segment, multi-dot, query, fragment, empty). Total: 1717 passing.
+
 ## [0.8.0] - 2026-04-22
 
 > **Breaking release focused on import/export.** The JSON and PMTiles export paths shipped in 0.7.0 and earlier were never standards-compliant — JSON produced a bespoke format nothing else reads, and the PMTiles implementation just wrapped that JSON in a `.pmtiles` extension. Both are removed. MBTiles is the only supported format now, and it's finally the real thing: v1.3-compliant SQLite that opens directly in QGIS, tippecanoe, and maplibre-native without conversion.

--- a/examples/mapbox-gl/public/idb-offline-sw.js
+++ b/examples/mapbox-gl/public/idb-offline-sw.js
@@ -243,6 +243,35 @@ async function handleGlyph(db, downloadId, rest) {
   return new Response('Glyph not found', { status: 404 });
 }
 
+async function handleModel(db, downloadId, rest) {
+  // Model URLs are rewritten by patchStyleForOffline to
+  //   idb://{styleId}/model/{modelName}  (served as /__offline__/{styleId}/model/{modelName})
+  // and stored under the key  {styleId}::model::{modelName}.  Mirror the
+  // sprite fallback: try the style ID first, then the download/region ID.
+  const styleEntry = await findStyleByRegionId(db, downloadId);
+  const actualStyleId = styleEntry ? styleEntry.key : downloadId;
+  const resourcePath = decodeURIComponent(rest.join('/'));
+
+  const candidates = Array.from(
+    new Set([
+      `${actualStyleId}::model::${resourcePath}`,
+      `${downloadId}::model::${resourcePath}`,
+    ])
+  );
+
+  for (const key of candidates) {
+    const resource = await idbGet(db, 'models', key);
+    if (resource && resource.data) {
+      return new Response(resource.data, {
+        status: 200,
+        headers: { 'Content-Type': resource.contentType || 'model/gltf-binary' },
+      });
+    }
+  }
+
+  return new Response('Model not found', { status: 404 });
+}
+
 async function handleSprite(db, downloadId, rest) {
   const styleEntry = await findStyleByRegionId(db, downloadId);
   const actualStyleId = styleEntry ? styleEntry.key : downloadId;
@@ -384,6 +413,8 @@ async function handleOfflineRequest(url, prefixIndex) {
         return await handleGlyph(db, downloadId, rest);
       case 'sprite':
         return await handleSprite(db, downloadId, rest);
+      case 'model':
+        return await handleModel(db, downloadId, rest);
       case 'tilesjson':
         return await handleTileJSON(db, downloadId, rest);
       default:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "map-gl-offline",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "A TypeScript-compatible npm package for MapLibre GL JS that enables comprehensive offline storage and usage of vector/raster tiles, sprites, styles, fonts (glyphs), and entire map regions with advanced analytics, import/export capabilities, and intelligent cleanup.",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/public/idb-offline-sw.js
+++ b/public/idb-offline-sw.js
@@ -243,6 +243,35 @@ async function handleGlyph(db, downloadId, rest) {
   return new Response('Glyph not found', { status: 404 });
 }
 
+async function handleModel(db, downloadId, rest) {
+  // Model URLs are rewritten by patchStyleForOffline to
+  //   idb://{styleId}/model/{modelName}  (served as /__offline__/{styleId}/model/{modelName})
+  // and stored under the key  {styleId}::model::{modelName}.  Mirror the
+  // sprite fallback: try the style ID first, then the download/region ID.
+  const styleEntry = await findStyleByRegionId(db, downloadId);
+  const actualStyleId = styleEntry ? styleEntry.key : downloadId;
+  const resourcePath = decodeURIComponent(rest.join('/'));
+
+  const candidates = Array.from(
+    new Set([
+      `${actualStyleId}::model::${resourcePath}`,
+      `${downloadId}::model::${resourcePath}`,
+    ])
+  );
+
+  for (const key of candidates) {
+    const resource = await idbGet(db, 'models', key);
+    if (resource && resource.data) {
+      return new Response(resource.data, {
+        status: 200,
+        headers: { 'Content-Type': resource.contentType || 'model/gltf-binary' },
+      });
+    }
+  }
+
+  return new Response('Model not found', { status: 404 });
+}
+
 async function handleSprite(db, downloadId, rest) {
   const styleEntry = await findStyleByRegionId(db, downloadId);
   const actualStyleId = styleEntry ? styleEntry.key : downloadId;
@@ -384,6 +413,8 @@ async function handleOfflineRequest(url, prefixIndex) {
         return await handleGlyph(db, downloadId, rest);
       case 'sprite':
         return await handleSprite(db, downloadId, rest);
+      case 'model':
+        return await handleModel(db, downloadId, rest);
       case 'tilesjson':
         return await handleTileJSON(db, downloadId, rest);
       default:

--- a/src/services/tileService.ts
+++ b/src/services/tileService.ts
@@ -7,6 +7,7 @@ import {
   validateResource,
   logger,
   createTileKey,
+  extractTileExtensionFromUrl,
 } from '@/utils';
 import {
   isMapboxProtocol,
@@ -1033,8 +1034,7 @@ export class TileService {
   }
 
   private extractExtension(template: string): string {
-    const extMatch = template.match(/\.([\w]+)(?:\?|$)/i);
-    return extMatch ? extMatch[1] : 'pbf';
+    return extractTileExtensionFromUrl(template);
   }
 
   private selectTileTemplate(

--- a/src/ui/managers/PanelManager.ts
+++ b/src/ui/managers/PanelManager.ts
@@ -21,6 +21,7 @@ const panelLogger = logger.scope('PanelManager');
 import { icons } from '@/utils/icons';
 import type { MapboxStyle, StyleStorageItem } from '@/types/style';
 import { convertStyleForServiceWorker } from '@/utils/convertStyleForSW';
+import { sanitizeIndoorExpressions } from '@/utils/importResolver';
 
 // Import modular components
 import { List, ListItemConfig } from '@/ui/components/shared/List';
@@ -1299,6 +1300,10 @@ export class PanelRenderer extends BaseComponent {
         delete (patchedStyle as Record<string, unknown>).imports;
         panelLogger.debug('Stripped imports from offline style (already flattened)');
       }
+
+      // Scrub indoor-only expressions for pre-0.8.1 stored styles that were
+      // downloaded before resolveImports learned to rewrite them.
+      sanitizeIndoorExpressions(patchedStyle);
 
       // Enforce maxzoom for all tile sources to prevent requesting non-existent tiles
       // Find the maximum zoom level from all regions using this style

--- a/src/ui/offlineManagerControl.ts
+++ b/src/ui/offlineManagerControl.ts
@@ -47,6 +47,7 @@ import {
   unregisterOfflineServiceWorker,
 } from '@/utils/swRegistration';
 import { convertStyleForServiceWorker } from '@/utils/convertStyleForSW';
+import { sanitizeIndoorExpressions } from '@/utils/importResolver';
 import type { MapboxStyle } from '@/types/style';
 
 // Import refactored modular components
@@ -767,6 +768,10 @@ export class OfflineManagerControl implements IControl {
       if ((patchedStyle as Record<string, unknown>).imports) {
         delete (patchedStyle as Record<string, unknown>).imports;
       }
+
+      // Scrub indoor-only expressions for pre-0.8.1 stored styles that were
+      // downloaded before resolveImports learned to rewrite them.
+      sanitizeIndoorExpressions(patchedStyle);
 
       // If using Service Worker (Mapbox GL JS), convert idb:// to /__offline__/ URLs
       if (this.useServiceWorker) {

--- a/src/utils/importResolver.ts
+++ b/src/utils/importResolver.ts
@@ -172,10 +172,8 @@ async function resolveImportsRecursive(
           prefixedLayer.source = `${importId}/${prefixedLayer.source}`;
         }
 
-        // Resolve ["config", "key"] expressions using schema defaults and import overrides
-        if (Object.keys(configValues).length > 0) {
-          resolveConfigExpressions(prefixedLayer, configValues);
-        }
+        // Resolve ["config", "key"] expressions using schema defaults and import overrides.
+        resolveConfigExpressions(prefixedLayer, configValues);
 
         flattenedLayers.push(prefixedLayer);
       }
@@ -222,7 +220,48 @@ async function resolveImportsRecursive(
     style.models = importedModels;
   }
 
+  // Rewrite indoor-only expressions so the flattened style validates without
+  // the `imports` wrapper at render time — see sanitizeIndoorExpressions.
+  sanitizeIndoorExpressions(style);
+
   return style;
+}
+
+/**
+ * Rewrite indoor-only expressions in a style's layers to their outdoor no-op
+ * constants. See the in-line comment in `resolveValue` for why this is needed
+ * for Mapbox Standard when the `imports` wrapper is stripped.
+ *
+ * Safe to call multiple times and on already-downloaded stored styles — the
+ * rewrites are idempotent (after the first pass there are no more
+ * `is-active-floor` / `floor-level` expressions to rewrite).
+ */
+export function sanitizeIndoorExpressions(style: BaseStyle): void {
+  const layers = (style as Record<string, unknown>).layers;
+  if (!Array.isArray(layers)) return;
+  for (const layer of layers) {
+    if (layer && typeof layer === 'object') {
+      rewriteIndoor(layer as Record<string, unknown>);
+    }
+  }
+}
+
+function rewriteIndoor(obj: Record<string, unknown>): void {
+  for (const key of Object.keys(obj)) {
+    obj[key] = rewriteIndoorValue(obj[key]);
+  }
+}
+
+function rewriteIndoorValue(value: unknown): unknown {
+  if (!Array.isArray(value)) {
+    if (value && typeof value === 'object' && !ArrayBuffer.isView(value)) {
+      rewriteIndoor(value as Record<string, unknown>);
+    }
+    return value;
+  }
+  if (value[0] === 'is-active-floor') return false;
+  if (value[0] === 'floor-level' && value.length === 1) return 0;
+  return value.map(rewriteIndoorValue);
 }
 
 /**

--- a/src/utils/styleUtils.ts
+++ b/src/utils/styleUtils.ts
@@ -1,5 +1,6 @@
 import type { MapboxStyle } from '@/types/style';
 import { logger } from './logger';
+import { extractTileExtensionFromUrl } from './tileKey';
 
 const styleLogger = logger.scope('StyleUtils');
 
@@ -36,14 +37,15 @@ export function patchStyleForOffline(
 
     if (source.tiles) {
       const originalTiles = [...source.tiles];
-      // Patch to idb://{downloadId}/tile/{sourceKey}/{z}/{x}/{y}.ext
+      // Patch to idb://{downloadId}/tile/{sourceKey}/{z}/{x}/{y}.ext.
+      // Extension extraction goes through the shared extractTileExtensionFromUrl
+      // helper so the patched URL's extension matches what tileService used when
+      // storing — otherwise Mapbox v4 tile URLs (`{y}.vector.pbf`) produced a
+      // stored key under `.pbf` but a patched URL with `.vector`, forcing
+      // idbFetchHandler to fall through its pbf/mvt/png/jpg/webp fallback loop
+      // on every tile.
       source.tiles = source.tiles.map((url: string) => {
-        // Use stored tileExtension if available, otherwise try to extract from URL
-        let ext = tileExtension;
-        if (!ext) {
-          const extMatch = url.match(/\{z\}\/\{x\}\/\{y\}\.(\w+)/);
-          ext = extMatch ? extMatch[1] : 'pbf';
-        }
+        const ext = tileExtension ?? extractTileExtensionFromUrl(url);
         return `idb://${downloadId}/tile/${sourceKey}/{z}/{x}/{y}.${ext}`;
       });
       styleLogger.debug(

--- a/src/utils/tileKey.ts
+++ b/src/utils/tileKey.ts
@@ -55,16 +55,30 @@ export function parseTileKey(key: string): {
 }
 
 /**
+ * Extract the extension (the last dotted segment before `?`, `#`, or end) from
+ * a tile URL or tile URL template. Defaults to `"pbf"` when no extension can
+ * be parsed. For multi-extension URLs like Mapbox v4's `{y}.vector.pbf` this
+ * returns `"pbf"`, matching the key used when the tile is stored.
+ *
+ * Keeping extraction logic in one place ensures patchStyleForOffline (which
+ * rewrites tile URLs to `idb://` at load time) derives the same extension
+ * that tileService.extractExtension used at store time — otherwise the
+ * first-try lookup in idbFetchHandler misses and has to fall through its
+ * pbf/mvt/png/jpg/webp fallback loop.
+ */
+export function extractTileExtensionFromUrl(url: string): string {
+  const match = url.match(/\.([\w]+)(?:[?#]|$)/i);
+  return match ? match[1] : 'pbf';
+}
+
+/**
  * Derive tile extension from tile URL templates
  */
 export function deriveTileExtension(tiles?: unknown): string {
   if (Array.isArray(tiles) && tiles.length > 0) {
     const firstTile = tiles[0];
     if (typeof firstTile === 'string') {
-      const match = firstTile.match(/\.([\w]+)(?:\?|$)/i);
-      if (match) {
-        return match[1];
-      }
+      return extractTileExtensionFromUrl(firstTile);
     }
   }
   return 'pbf';

--- a/tests/utils/idbOfflineSW.test.ts
+++ b/tests/utils/idbOfflineSW.test.ts
@@ -56,10 +56,18 @@ function wouldIntercept(url: string): boolean {
 /** Open the same DB the SW uses so we can seed data */
 function openTestDB(): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
-    const req = indexedDB.open('offline-map-db', 3);
+    const req = indexedDB.open('offline-map-db', 4);
     req.onupgradeneeded = () => {
       const db = req.result;
-      for (const name of ['regions', 'tiles', 'styles', 'sprites', 'glyphs', 'fonts']) {
+      for (const name of [
+        'regions',
+        'tiles',
+        'styles',
+        'sprites',
+        'glyphs',
+        'fonts',
+        'models',
+      ]) {
         if (!db.objectStoreNames.contains(name)) {
           db.createObjectStore(name, { keyPath: 'key' });
         }
@@ -198,6 +206,7 @@ describe('idb-offline-sw.js', () => {
     await clearStore(db, 'sprites');
     await clearStore(db, 'glyphs');
     await clearStore(db, 'fonts');
+    await clearStore(db, 'models');
   });
 
   afterAll(() => {
@@ -622,6 +631,68 @@ describe('idb-offline-sw.js', () => {
       expect(resp.status).toBe(200);
       // No Content-Type header when resource has none
       expect(resp.headers.get('Content-Type')).toBeNull();
+    });
+  });
+
+  // -----------------------------------------------------------
+  // Model handling (Mapbox Standard 3D trees / wind turbines)
+  // -----------------------------------------------------------
+
+  describe('model handling', () => {
+    it('should return 404 for non-existent model', async () => {
+      const resp = await swFetch(
+        'https://localhost/__offline__/mapbox-standard/model/maple1-lod1'
+      );
+      expect(resp.status).toBe(404);
+    });
+
+    it('should serve a stored .glb with default content-type', async () => {
+      const glb = new ArrayBuffer(1024);
+      await idbPut(db, 'models', {
+        key: 'mapbox-standard::model::maple1-lod1',
+        data: glb,
+      });
+
+      const resp = await swFetch(
+        'https://localhost/__offline__/mapbox-standard/model/maple1-lod1'
+      );
+      expect(resp.status).toBe(200);
+      expect(resp.headers.get('Content-Type')).toBe('model/gltf-binary');
+    });
+
+    it('should respect a stored contentType override', async () => {
+      const glb = new ArrayBuffer(512);
+      await idbPut(db, 'models', {
+        key: 'mapbox-standard::model::wind-turbine-blade',
+        data: glb,
+        contentType: 'application/octet-stream',
+      });
+
+      const resp = await swFetch(
+        'https://localhost/__offline__/mapbox-standard/model/wind-turbine-blade'
+      );
+      expect(resp.status).toBe(200);
+      expect(resp.headers.get('Content-Type')).toBe('application/octet-stream');
+    });
+
+    it('should resolve a model via region ID', async () => {
+      // Style stored under `mapbox-standard`; region `region-m` belongs to it.
+      await idbPut(db, 'styles', {
+        key: 'mapbox-standard',
+        style: { version: 8, sources: {}, layers: [] },
+        regions: [{ id: 'region-m', name: 'Test' }],
+      });
+      const glb = new ArrayBuffer(256);
+      await idbPut(db, 'models', {
+        key: 'mapbox-standard::model::palm2-lod2',
+        data: glb,
+      });
+
+      const resp = await swFetch(
+        'https://localhost/__offline__/region-m/model/palm2-lod2'
+      );
+      expect(resp.status).toBe(200);
+      expect(resp.headers.get('Content-Type')).toBe('model/gltf-binary');
     });
   });
 

--- a/tests/utils/importResolver.test.ts
+++ b/tests/utils/importResolver.test.ts
@@ -1,7 +1,11 @@
 /**
  * Tests for Import Resolution (Mapbox Standard style support)
  */
-import { hasImports, resolveImports } from '../../src/utils/importResolver';
+import {
+  hasImports,
+  resolveImports,
+  sanitizeIndoorExpressions,
+} from '../../src/utils/importResolver';
 import type { BaseStyle } from '../../src/types/style';
 
 // Mock global fetch
@@ -572,6 +576,119 @@ describe('importResolver', () => {
       const textFont = layout['text-font'] as unknown[];
       expect(textFont[0]).toBe('literal');
       expect((textFont[1] as unknown[])[0]).toBe('DIN Pro');
+    });
+  });
+
+  describe('sanitizeIndoorExpressions', () => {
+    it('rewrites ["is-active-floor"] to false inside filters', () => {
+      const style = makeStyle({
+        layers: [
+          {
+            id: 'indoor-clip',
+            type: 'clip',
+            filter: ['all', ['is-active-floor'], ['==', ['get', 'shape_type'], 'building']],
+          },
+        ],
+      } as Partial<BaseStyle>);
+
+      sanitizeIndoorExpressions(style);
+
+      expect((style.layers[0] as { filter: unknown[] }).filter).toEqual([
+        'all',
+        false,
+        ['==', ['get', 'shape_type'], 'building'],
+      ]);
+    });
+
+    it('rewrites ["is-active-floor", <id>] to false (the arg form)', () => {
+      const style = makeStyle({
+        layers: [
+          { id: 'indoor-floor', type: 'fill', filter: ['is-active-floor', ['get', 'id']] },
+        ],
+      } as Partial<BaseStyle>);
+
+      sanitizeIndoorExpressions(style);
+
+      expect((style.layers[0] as { filter: unknown }).filter).toBe(false);
+    });
+
+    it('rewrites ["floor-level"] to 0', () => {
+      const style = makeStyle({
+        layers: [{ id: 'x', type: 'fill', paint: { 'fill-opacity': ['floor-level'] } }],
+      } as Partial<BaseStyle>);
+
+      sanitizeIndoorExpressions(style);
+
+      const paint = (style.layers[0] as { paint: Record<string, unknown> }).paint;
+      expect(paint['fill-opacity']).toBe(0);
+    });
+
+    it('leaves unrelated expressions alone', () => {
+      const style = makeStyle({
+        layers: [
+          {
+            id: 'road',
+            type: 'line',
+            source: 'composite',
+            filter: ['all', ['==', ['get', 'class'], 'motorway'], ['!', ['has', 'tunnel']]],
+          },
+        ],
+      } as Partial<BaseStyle>);
+      const before = JSON.stringify(style);
+
+      sanitizeIndoorExpressions(style);
+
+      expect(JSON.stringify(style)).toBe(before);
+    });
+
+    it('is idempotent — running twice yields the same result', () => {
+      const style = makeStyle({
+        layers: [
+          {
+            id: 'label',
+            type: 'symbol',
+            filter: ['any', ['!', ['is-active-floor']], ['==', ['get', 'class'], 'gate']],
+          },
+        ],
+      } as Partial<BaseStyle>);
+
+      sanitizeIndoorExpressions(style);
+      const once = JSON.stringify(style);
+      sanitizeIndoorExpressions(style);
+      expect(JSON.stringify(style)).toBe(once);
+    });
+
+    it('runs automatically at the end of resolveImports', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockFetchResponse({
+          version: 8,
+          sources: { composite: { type: 'vector' } },
+          layers: [
+            {
+              id: 'indoor-floor',
+              type: 'fill',
+              source: 'composite',
+              filter: ['is-active-floor', ['get', 'floor_id']],
+            },
+          ],
+        })
+      );
+
+      const style: BaseStyle = {
+        version: 8,
+        imports: [{ id: 'basemap', url: 'https://example.com/basemap.json' }],
+        sources: {},
+        layers: [],
+      };
+
+      const result = await resolveImports(style, 'test-token');
+
+      // The imported indoor-floor layer should have its filter rewritten.
+      const indoor = (result.layers as Array<Record<string, unknown>>).find(
+        l => l.id === 'basemap/indoor-floor'
+      );
+      expect(indoor).toBeDefined();
+      expect(indoor!.filter).toBe(false);
     });
   });
 });

--- a/tests/utils/tileKey.test.ts
+++ b/tests/utils/tileKey.test.ts
@@ -1,7 +1,12 @@
 /**
  * Tests for tile key utilities
  */
-import { createTileKey, parseTileKey, deriveTileExtension } from '../../src/utils/tileKey';
+import {
+  createTileKey,
+  parseTileKey,
+  deriveTileExtension,
+  extractTileExtensionFromUrl,
+} from '../../src/utils/tileKey';
 
 describe('createTileKey', () => {
   it('should create a tile key in the correct format', () => {
@@ -131,5 +136,41 @@ describe('deriveTileExtension', () => {
   it('should handle case-insensitive extensions', () => {
     expect(deriveTileExtension(['https://example.com/tiles/{z}/{x}/{y}.PNG'])).toBe('PNG');
     expect(deriveTileExtension(['https://example.com/tiles/{z}/{x}/{y}.Pbf'])).toBe('Pbf');
+  });
+});
+
+describe('extractTileExtensionFromUrl', () => {
+  it('extracts single-segment extensions', () => {
+    expect(extractTileExtensionFromUrl('https://x/{z}/{x}/{y}.pbf')).toBe('pbf');
+    expect(extractTileExtensionFromUrl('https://x/{z}/{x}/{y}.png')).toBe('png');
+  });
+
+  it('extracts the last segment from multi-dot Mapbox v4 URLs', () => {
+    // Mapbox returns vector tiles under `.vector.pbf`. tileService stores the key
+    // using the last segment, so patchStyleForOffline must agree or every tile
+    // fetch falls through idbFetchHandler's fallback-extension loop.
+    expect(
+      extractTileExtensionFromUrl(
+        'https://api.mapbox.com/v4/mapbox.streets-v8/{z}/{x}/{y}.vector.pbf'
+      )
+    ).toBe('pbf');
+  });
+
+  it('ignores query strings', () => {
+    expect(
+      extractTileExtensionFromUrl(
+        'https://api.mapbox.com/v4/.../{z}/{x}/{y}.vector.pbf?access_token=sk.abc'
+      )
+    ).toBe('pbf');
+    expect(extractTileExtensionFromUrl('https://x/{z}/{x}/{y}.pbf?token=x')).toBe('pbf');
+  });
+
+  it('ignores URL fragments', () => {
+    expect(extractTileExtensionFromUrl('https://x/{z}/{x}/{y}.pbf#frag')).toBe('pbf');
+  });
+
+  it('defaults to "pbf" when no extension is present', () => {
+    expect(extractTileExtensionFromUrl('https://x/{z}/{x}/{y}')).toBe('pbf');
+    expect(extractTileExtensionFromUrl('')).toBe('pbf');
   });
 });


### PR DESCRIPTION
## Summary

Three independent fixes that together let a downloaded **Mapbox Standard** region actually render offline in Mapbox GL v3.

1. **`is-active-floor` / `floor-level` crash (the blocker).** Mapbox Standard's indoor layers filter on `["is-active-floor"]`, an expression Mapbox GL v3 evaluates against `map.indoor.activeFloors` at filter-compile time. Stripping the `imports` wrapper at storage left that state null and `setStyle()` hung forever with `"Style is not done loading"`. New exported `sanitizeIndoorExpressions()` rewrites the two indoor expressions to their outdoor no-op constants (`false` / `0`). Runs at the end of `resolveImports` (download) **and** in both UI load paths, so pre-0.8.1 stored styles heal in place — no re-download needed.
2. **SW was missing its `model` case.** `public/idb-offline-sw.js` only handled tile/glyph/sprite/tilesjson, so worker-scoped `.glb` fetches for 3D trees / wind turbines 400'd. Main-thread fetches worked via the `window.fetch` override; worker-thread ones didn't. Added `handleModel` mirroring the sprite resolver.
3. **Tile-extension regex.** `patchStyleForOffline` captured only the first dotted segment of Mapbox v4 `.vector.pbf` URLs while `tileService.extractExtension` captured the last. Every tile fetch went through `idbFetchHandler`'s pbf/mvt/png/jpg/webp fallback loop before resolving. Factored extraction into a single `extractTileExtensionFromUrl()` helper in `tileKey.ts`.

+15 tests (6 sanitizer, 4 SW model handler, 5 extension helper) — 1717 total passing.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npx jest` — 1717 / 1717 pass (was 1702, +15 new)
- [x] `npm run lint` clean
- [x] End-to-end in browser: downloaded a Mapbox Standard region, enabled Chrome DevTools **Offline** emulation, clicked **Load Style**, panned and zoomed — rendered with Standard's pale roads, landmark icons (Burj Khalifa camera, Dubai Mall bag, Coca-Cola Arena cup), DIN Pro typography, cream pedestrian zones, blue water. Zero console errors.
- [ ] Reviewer: verify Mapbox GL v3 still wraps the imports-less flat style in an implicit `basemap` import at setStyle time (the existing behavior the fix relies on).

## Upgrade notes

None — no API changes. Existing regions downloaded on 0.8.0 work without re-download (the sanitizer runs at load time as a safety net). Re-downloading is only required to pick up the tile-extension fix, and even without that, tiles still resolve via the fallback loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)